### PR TITLE
feat: Add English and German translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Add professional phone buttons for each branch at the bottom of your website with icon customization, position control, and more.
+افزودن دکمه‌های تماس حرفه‌ای برای هر شعبه در پایین وب‌سایت شما با قابلیت شخصی‌سازی آیکون، کنترل موقعیت و موارد دیگر.
+Fügen Sie am Ende Ihrer Website professionelle Anruf-Buttons für jede Filiale hinzu, mit Symbolanpassung, Positionskontrolle und vielem mehr.
 
 == Description ==
 
@@ -22,10 +24,38 @@ This plugin allows you to:
 * Add custom CSS
 * Automatically purge LiteSpeed cache after saving settings
 
+**Persian:**
+این پلاگین به شما اجازه می‌دهد:
+* اضافه کردن چندین شماره تماس برای شعب مختلف
+* شخصی‌سازی رنگ پس‌زمینه دکمه‌ها
+* انتخاب آیکون و موقعیت آن (چپ یا راست)
+* تنظیم فاصله از پایین صفحه
+* اضافه کردن CSS سفارشی
+* پاکسازی خودکار کش LiteSpeed پس از ذخیره تنظیمات
+
+**Deutsch:**
+Dieses Plugin ermöglicht Ihnen:
+* Hinzufügen mehrerer Telefonnummern für verschiedene Filialen
+* Anpassen der Hintergrundfarbe der Schaltfläche
+* Auswählen des Symbols und seiner Position (links oder rechts)
+* Einstellen des Abstands vom unteren Rand der Seite
+* Hinzufügen von benutzerdefiniertem CSS
+* Automatisches Löschen des LiteSpeed-Caches nach dem Speichern der Einstellungen
+
 == Installation ==
 1. Upload the plugin to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 3. Configure settings in the "Branch Phone Buttons" page under the Settings menu.
+
+**Persian:**
+1. افزونه را در دایرکتوری `/wp-content/plugins/` بارگذاری کنید.
+2. افزونه را از طریق منوی "افزونه‌ها" در وردپرس فعال کنید.
+3. تنظیمات را در صفحه "Branch Phone Buttons" زیر منوی تنظیمات پیکربندی کنید.
+
+**Deutsch:**
+1. Laden Sie das Plugin in das Verzeichnis `/wp-content/plugins/` hoch.
+2. Aktivieren Sie das Plugin über das Menü "Plugins" in WordPress.
+3. Konfigurieren Sie die Einstellungen auf der Seite "Branch Phone Buttons" im Menü Einstellungen.
 
 == Frequently Asked Questions ==
 = Does this work with LiteSpeed? =
@@ -34,7 +64,23 @@ Yes. Cache is automatically purged after settings are saved.
 = Is this plugin customizable? =
 Yes. You can define custom CSS and control many visual aspects.
 
+**Persian:**
+= آیا با LiteSpeed سازگار است؟ =
+بله. کش به طور خودکار پس از ذخیره تنظیمات پاک می‌شود.
+
+= آیا این افزونه قابل شخصی‌سازی است؟ =
+بله. شما می‌توانید CSS سفارشی تعریف کنید و بسیاری از جنبه‌های بصری را کنترل کنید.
+
+**Deutsch:**
+= Funktioniert das mit LiteSpeed? =
+Ja. Der Cache wird nach dem Speichern der Einstellungen automatisch geleert.
+
+= Ist dieses Plugin anpassbar? =
+Ja. Sie können benutzerdefiniertes CSS definieren und viele visuelle Aspekte steuern.
+
 == Changelog ==
 = 1.0.0 =
 * Initial release with all key features
+* انتشار اولیه با تمام ویژگی‌های کلیدی
+* Erste Veröffentlichung mit allen Hauptfunktionen
 

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -1,85 +1,102 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
+// Simple locale detection for translations
+function bpb_t($persian, $english, $german) {
+    $locale = function_exists('get_user_locale') ? get_user_locale() : get_locale();
+    if (strpos($locale, 'de_') === 0) {
+        return $german;
+    } elseif (strpos($locale, 'en_') === 0) {
+        return $english;
+    }
+    return $persian;
+}
+
 add_action('admin_menu', function() {
-    add_menu_page('تنظیمات دکمه تماس (Call Button Settings / Anruf-Button-Einstellungen)', 'تماس شعب (Branch Contact / Filialkontakt)', 'manage_options', 'bpb-settings', 'bpb_render_settings_page');
+    add_menu_page(
+        bpb_t('تنظیمات دکمه تماس', 'Call Button Settings', 'Anruf-Button-Einstellungen'),
+        bpb_t('تماس شعب', 'Branch Contact', 'Filialkontakt'),
+        'manage_options',
+        'bpb-settings',
+        'bpb_render_settings_page'
+    );
 });
 
 function bpb_render_settings_page() {
     if (isset($_POST['bpb_save']) && check_admin_referer('bpb_settings_action', 'bpb_settings_nonce')) {
         update_option('bpb_settings', $_POST['bpb_settings']);
-        echo '<div class="updated"><p>تنظیمات ذخیره شد. (Settings saved. / Einstellungen gespeichert.)</p></div>';
+        echo '<div class="updated"><p>' . esc_html(bpb_t('تنظیمات ذخیره شد.', 'Settings saved.', 'Einstellungen gespeichert.')) . '</p></div>';
     }
 
     if (isset($_POST['bpb_reset_stats']) && check_admin_referer('bpb_settings_action', 'bpb_settings_nonce')) {
         update_option('bpb_click_stats', []);
-        echo '<div class="updated"><p>آمار کلیک‌ها بازنشانی شد. (Click stats reset. / Klickstatistiken zurückgesetzt.)</p></div>';
+        echo '<div class="updated"><p>' . esc_html(bpb_t('آمار کلیک‌ها بازنشانی شد.', 'Click stats reset.', 'Klickstatistiken zurückgesetzt.')) . '</p></div>';
     }
 
     $settings = get_option('bpb_settings', bpb_default_settings());
     $stats = get_option('bpb_click_stats', []);
     ?>
     <div class="wrap">
-        <h1>تنظیمات دکمه تماس شعب (Branch Phone Button Settings / Filial-Anruf-Button-Einstellungen) - نسخه 1.2</h1>
+        <h1><?php echo esc_html(bpb_t('تنظیمات دکمه تماس شعب', 'Branch Phone Button Settings', 'Filial-Anruf-Button-Einstellungen')); ?> - نسخه 1.2</h1>
         <form method="post">
             <?php wp_nonce_field('bpb_settings_action', 'bpb_settings_nonce'); ?>
             <table class="form-table">
                 <tr>
-                    <th scope="row">حالت نمایش (Display Mode / Anzeigemodus)</th>
+                    <th scope="row"><?php echo esc_html(bpb_t('حالت نمایش', 'Display Mode', 'Anzeigemodus')); ?></th>
                     <td>
                         <label>
                             <input type="radio" name="bpb_settings[mode]" value="branches" <?php checked($settings['mode'] ?? 'branches', 'branches'); ?>>
-                            حالت شعب (چند شعبه) - Branches Mode (Multiple Branches) - Filialmodus (Mehrere Filialen)
+                            <?php echo esc_html(bpb_t('حالت شعب (چند شعبه)', 'Branches Mode (Multiple Branches)', 'Filialmodus (Mehrere Filialen)')); ?>
                         </label><br>
                         <label>
                             <input type="radio" name="bpb_settings[mode]" value="contacts" <?php checked($settings['mode'] ?? 'branches', 'contacts'); ?>>
-                            حالت راه‌های ارتباطی (تماس، ایمیل و ...) - Contacts Mode (Call, Email, etc.) - Kontaktmodus (Anruf, E-Mail usw.)
+                            <?php echo esc_html(bpb_t('حالت راه‌های ارتباطی (تماس، ایمیل و ...)', 'Contacts Mode (Call, Email, etc.)', 'Kontaktmodus (Anruf, E-Mail usw.)')); ?>
                         </label>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">تأخیر نمایش (ثانیه) <br>(Display Delay (sec) / Anzeigeverzögerung (Sek.))</th>
+                    <th scope="row"><?php echo esc_html(bpb_t('تأخیر نمایش (ثانیه)', 'Display Delay (sec)', 'Anzeigeverzögerung (Sek.)')); ?></th>
                     <td>
                         <input type="number" name="bpb_settings[delay]" value="<?php echo esc_attr($settings['delay'] ?? 0); ?>" min="0" />
-                        <p class="description">تعداد ثانیه‌هایی که طول می‌کشد تا دکمه‌ها نمایش داده شوند. 0 برای نمایش فوری.<br>(Seconds until buttons are displayed. 0 for instant display. / Sekunden bis die Schaltflächen angezeigt werden. 0 für sofortige Anzeige.)</p>
+                        <p class="description"><?php echo esc_html(bpb_t('تعداد ثانیه‌هایی که طول می‌کشد تا دکمه‌ها نمایش داده شوند. 0 برای نمایش فوری.', 'Seconds until buttons are displayed. 0 for instant display.', 'Sekunden bis die Schaltflächen angezeigt werden. 0 für sofortige Anzeige.')); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">نحوه نمایش (Display Style / Anzeigestil)</th>
+                    <th scope="row"><?php echo esc_html(bpb_t('نحوه نمایش', 'Display Style', 'Anzeigestil')); ?></th>
                     <td>
                         <select name="bpb_settings[display_style]">
-                            <option value="flat" <?php selected($settings['display_style'] ?? 'flat', 'flat'); ?>>چسبیده به پایین (کامل) - Sticky Bottom (Full) - Unten anheften (Vollständig)</option>
-                            <option value="floating" <?php selected($settings['display_style'] ?? 'flat', 'floating'); ?>>شناور (گرد) - Floating (Round) - Schwebend (Rund)</option>
+                            <option value="flat" <?php selected($settings['display_style'] ?? 'flat', 'flat'); ?>><?php echo esc_html(bpb_t('چسبیده به پایین (کامل)', 'Sticky Bottom (Full)', 'Unten anheften (Vollständig)')); ?></option>
+                            <option value="floating" <?php selected($settings['display_style'] ?? 'flat', 'floating'); ?>><?php echo esc_html(bpb_t('شناور (گرد)', 'Floating (Round)', 'Schwebend (Rund)')); ?></option>
                         </select>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">قوانین نمایش (صفحات) <br>(Display Rules (Pages) / Anzeigeregeln (Seiten))</th>
+                    <th scope="row"><?php echo esc_html(bpb_t('قوانین نمایش (صفحات)', 'Display Rules (Pages)', 'Anzeigeregeln (Seiten)')); ?></th>
                     <td>
                         <label>
                             <input type="checkbox" name="bpb_settings[show_only_homepage]" value="1" <?php checked($settings['show_only_homepage'] ?? 0, 1); ?>>
-                            فقط در صفحه اصلی نمایش داده شود (Show only on homepage / Nur auf der Startseite anzeigen)
+                            <?php echo esc_html(bpb_t('فقط در صفحه اصلی نمایش داده شود', 'Show only on homepage', 'Nur auf der Startseite anzeigen')); ?>
                         </label><br>
                         <label>
                             <input type="checkbox" name="bpb_settings[hide_on_woo_checkout]" value="1" <?php checked($settings['hide_on_woo_checkout'] ?? 0, 1); ?>>
-                            عدم نمایش در صفحه سبد خرید و پرداخت ووکامرس (Hide on WooCommerce Cart & Checkout / Ausblenden auf WooCommerce Warenkorb & Kasse)
+                            <?php echo esc_html(bpb_t('عدم نمایش در صفحه سبد خرید و پرداخت ووکامرس', 'Hide on WooCommerce Cart & Checkout', 'Ausblenden auf WooCommerce Warenkorb & Kasse')); ?>
                         </label>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">ساعات کاری اداری <br>(Business Hours / Geschäftszeiten)</th>
+                    <th scope="row"><?php echo esc_html(bpb_t('ساعات کاری اداری', 'Business Hours', 'Geschäftszeiten')); ?></th>
                     <td>
-                        از (From / Von) <input type="time" name="bpb_settings[biz_time_start]" value="<?php echo esc_attr($settings['biz_time_start'] ?? '08:00'); ?>" />
-                        تا (To / Bis) <input type="time" name="bpb_settings[biz_time_end]" value="<?php echo esc_attr($settings['biz_time_end'] ?? '17:00'); ?>" />
-                        <p class="description">بر اساس منطقه زمانی وردپرس (تنظیمات > عمومی). می‌توانید دکمه‌ها را محدود به این ساعات کنید.<br>(Based on WordPress timezone (Settings > General). You can limit buttons to these hours. / Basierend auf der WordPress-Zeitzone (Einstellungen > Allgemein). Sie können die Schaltflächen auf diese Zeiten beschränken.)</p>
+                        <?php echo esc_html(bpb_t('از', 'From', 'Von')); ?> <input type="time" name="bpb_settings[biz_time_start]" value="<?php echo esc_attr($settings['biz_time_start'] ?? '08:00'); ?>" />
+                        <?php echo esc_html(bpb_t('تا', 'To', 'Bis')); ?> <input type="time" name="bpb_settings[biz_time_end]" value="<?php echo esc_attr($settings['biz_time_end'] ?? '17:00'); ?>" />
+                        <p class="description"><?php echo esc_html(bpb_t('بر اساس منطقه زمانی وردپرس (تنظیمات > عمومی). می‌توانید دکمه‌ها را محدود به این ساعات کنید.', 'Based on WordPress timezone (Settings > General). You can limit buttons to these hours.', 'Basierend auf der WordPress-Zeitzone (Einstellungen > Allgemein). Sie können die Schaltflächen auf diese Zeiten beschränken.')); ?></p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">رهگیری آمار <br>(Analytics Tracking / Analyse-Tracking)</th>
+                    <th scope="row"><?php echo esc_html(bpb_t('رهگیری آمار', 'Analytics Tracking', 'Analyse-Tracking')); ?></th>
                     <td>
                         <label>
                             <input type="checkbox" name="bpb_settings[enable_ga_tracking]" value="1" <?php checked($settings['enable_ga_tracking'] ?? 0, 1); ?>>
-                            ثبت کلیک‌ها در گوگل آنالیتیکس (Log clicks in Google Analytics (Gtag) / Klicks in Google Analytics erfassen (Gtag))
+                            <?php echo esc_html(bpb_t('ثبت کلیک‌ها در گوگل آنالیتیکس (Gtag)', 'Log clicks in Google Analytics (Gtag)', 'Klicks in Google Analytics erfassen (Gtag)')); ?>
                         </label>
                     </td>
                 </tr>
@@ -88,7 +105,7 @@ function bpb_render_settings_page() {
             <hr>
 
             <div id="bpb-branches-wrapper">
-                <h2>دکمه‌های حالت شعب (Branch Mode Buttons / Schaltflächen für den Filialmodus)</h2>
+                <h2><?php echo esc_html(bpb_t('دکمه‌های حالت شعب', 'Branch Mode Buttons', 'Schaltflächen für den Filialmodus')); ?></h2>
                 <table class="form-table" id="bpb-branches-table">
                     <tbody>
                         <?php
@@ -101,41 +118,41 @@ function bpb_render_settings_page() {
                             $val = $branch['value'] ?? ($branch['phone'] ?? '');
                         ?>
                             <tr class="bpb-branch-row">
-                                <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه (Button)</th>
+                                <th><span class="dashicons dashicons-move" style="cursor:move;"></span> <?php echo esc_html(bpb_t('دکمه', 'Button', 'Schaltfläche')); ?></th>
                                 <td>
-                                    نام (Name): <input type="text" name="bpb_settings[branches][<?php echo $i ?>][label]" value="<?php echo esc_attr($branch['label']) ?>" />
+                                    <?php echo esc_html(bpb_t('نام', 'Name', 'Name')); ?>: <input type="text" name="bpb_settings[branches][<?php echo $i ?>][label]" value="<?php echo esc_attr($branch['label']) ?>" />
 
-                                    نوع اتصال (Connection Type / Verbindungstyp):
+                                    <?php echo esc_html(bpb_t('نوع اتصال', 'Connection Type', 'Verbindungstyp')); ?>:
                                     <select name="bpb_settings[branches][<?php echo $i ?>][type]">
-                                        <option value="tel" <?php selected($type, 'tel'); ?>>تلفن (Phone / Telefon)</option>
-                                        <option value="mailto" <?php selected($type, 'mailto'); ?>>ایمیل (Email / E-Mail)</option>
-                                        <option value="whatsapp" <?php selected($type, 'whatsapp'); ?>>واتس‌اپ (WhatsApp)</option>
-                                        <option value="telegram" <?php selected($type, 'telegram'); ?>>تلگرام (Telegram)</option>
-                                        <option value="link" <?php selected($type, 'link'); ?>>لینک دلخواه (Custom Link / Benutzerdefinierter Link)</option>
+                                        <option value="tel" <?php selected($type, 'tel'); ?>><?php echo esc_html(bpb_t('تلفن', 'Phone', 'Telefon')); ?></option>
+                                        <option value="mailto" <?php selected($type, 'mailto'); ?>><?php echo esc_html(bpb_t('ایمیل', 'Email', 'E-Mail')); ?></option>
+                                        <option value="whatsapp" <?php selected($type, 'whatsapp'); ?>><?php echo esc_html(bpb_t('واتس‌اپ', 'WhatsApp', 'WhatsApp')); ?></option>
+                                        <option value="telegram" <?php selected($type, 'telegram'); ?>><?php echo esc_html(bpb_t('تلگرام', 'Telegram', 'Telegram')); ?></option>
+                                        <option value="link" <?php selected($type, 'link'); ?>><?php echo esc_html(bpb_t('لینک دلخواه', 'Custom Link', 'Benutzerdefinierter Link')); ?></option>
                                     </select>
 
-                                    مقدار (Value / Wert): <input type="text" name="bpb_settings[branches][<?php echo $i ?>][value]" value="<?php echo esc_attr($val) ?>" />
+                                    <?php echo esc_html(bpb_t('مقدار', 'Value', 'Wert')); ?>: <input type="text" name="bpb_settings[branches][<?php echo $i ?>][value]" value="<?php echo esc_attr($val) ?>" />
 
-                                    آیکون (Icon / Symbol):
+                                    <?php echo esc_html(bpb_t('آیکون', 'Icon', 'Symbol')); ?>:
                                     <select name="bpb_settings[branches][<?php echo $i ?>][icon]">
-                                        <option value="phone" <?php selected($icon, 'phone'); ?>>تلفن (Phone / Telefon)</option>
-                                        <option value="email" <?php selected($icon, 'email'); ?>>ایمیل (Email / E-Mail)</option>
-                                        <option value="whatsapp" <?php selected($icon, 'whatsapp'); ?>>واتس‌اپ (WhatsApp)</option>
-                                        <option value="telegram" <?php selected($icon, 'telegram'); ?>>تلگرام (Telegram)</option>
-                                        <option value="link" <?php selected($icon, 'link'); ?>>لینک (Link)</option>
+                                        <option value="phone" <?php selected($icon, 'phone'); ?>><?php echo esc_html(bpb_t('تلفن', 'Phone', 'Telefon')); ?></option>
+                                        <option value="email" <?php selected($icon, 'email'); ?>><?php echo esc_html(bpb_t('ایمیل', 'Email', 'E-Mail')); ?></option>
+                                        <option value="whatsapp" <?php selected($icon, 'whatsapp'); ?>><?php echo esc_html(bpb_t('واتس‌اپ', 'WhatsApp', 'WhatsApp')); ?></option>
+                                        <option value="telegram" <?php selected($icon, 'telegram'); ?>><?php echo esc_html(bpb_t('تلگرام', 'Telegram', 'Telegram')); ?></option>
+                                        <option value="link" <?php selected($icon, 'link'); ?>><?php echo esc_html(bpb_t('لینک', 'Link', 'Link')); ?></option>
                                     </select>
 
-                                    زمان نمایش (Display Time / Anzeigezeit):
+                                    <?php echo esc_html(bpb_t('زمان نمایش', 'Display Time', 'Anzeigezeit')); ?>:
                                     <select name="bpb_settings[branches][<?php echo $i ?>][timing]">
-                                        <option value="always" <?php selected($timing, 'always'); ?>>همیشه (Always / Immer)</option>
-                                        <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>>فقط در ساعات کاری (Business Hours Only / Nur Geschäftszeiten)</option>
-                                        <option value="off_hours" <?php selected($timing, 'off_hours'); ?>>فقط خارج از ساعات کاری (Off Hours Only / Nur außerhalb der Geschäftszeiten)</option>
+                                        <option value="always" <?php selected($timing, 'always'); ?>><?php echo esc_html(bpb_t('همیشه', 'Always', 'Immer')); ?></option>
+                                        <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>><?php echo esc_html(bpb_t('فقط در ساعات کاری', 'Business Hours Only', 'Nur Geschäftszeiten')); ?></option>
+                                        <option value="off_hours" <?php selected($timing, 'off_hours'); ?>><?php echo esc_html(bpb_t('فقط خارج از ساعات کاری', 'Off Hours Only', 'Nur außerhalb der Geschäftszeiten')); ?></option>
                                     </select>
 
-                                    رنگ (Color / Farbe): <input type="text" class="bpb-color-picker" name="bpb_settings[branches][<?php echo $i ?>][color]" value="<?php echo esc_attr($branch['color']) ?>" />
-                                    سایز فونت (Font Size / Schriftgröße): <input type="number" name="bpb_settings[branches][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($branch['font_size'] ?? 14) ?>" style="width: 60px;" />
+                                    <?php echo esc_html(bpb_t('رنگ', 'Color', 'Farbe')); ?>: <input type="text" class="bpb-color-picker" name="bpb_settings[branches][<?php echo $i ?>][color]" value="<?php echo esc_attr($branch['color']) ?>" />
+                                    <?php echo esc_html(bpb_t('سایز فونت', 'Font Size', 'Schriftgröße')); ?>: <input type="number" name="bpb_settings[branches][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($branch['font_size'] ?? 14) ?>" style="width: 60px;" />
 
-                                    <button type="button" class="button bpb-remove-row">حذف (Remove / Entfernen)</button>
+                                    <button type="button" class="button bpb-remove-row"><?php echo esc_html(bpb_t('حذف', 'Remove', 'Entfernen')); ?></button>
 
                                     <input type="hidden" name="bpb_settings[branches][<?php echo $i ?>][order]" value="<?php echo $i ?>" class="bpb-order-field">
                                 </td>
@@ -143,11 +160,11 @@ function bpb_render_settings_page() {
                         <?php endforeach; ?>
                     </tbody>
                 </table>
-                <p><button type="button" id="bpb-add-branch-row" class="button bpb-add-row" data-target="branches">افزودن دکمه جدید (شعب) - Add New Branch Button - Neuen Filial-Button hinzufügen</button></p>
+                <p><button type="button" id="bpb-add-branch-row" class="button bpb-add-row" data-target="branches"><?php echo esc_html(bpb_t('افزودن دکمه جدید (شعب)', 'Add New Branch Button', 'Neuen Filial-Button hinzufügen')); ?></button></p>
             </div>
 
             <div id="bpb-contacts-wrapper">
-                <h2>دکمه‌های حالت راه‌های ارتباطی (Contacts Mode Buttons / Schaltflächen für den Kontaktmodus)</h2>
+                <h2><?php echo esc_html(bpb_t('دکمه‌های حالت راه‌های ارتباطی', 'Contacts Mode Buttons', 'Schaltflächen für den Kontaktmodus')); ?></h2>
                 <table class="form-table" id="bpb-contacts-table">
                     <tbody>
                         <?php
@@ -159,41 +176,41 @@ function bpb_render_settings_page() {
                             $val = $contact['value'] ?? ($contact['phone'] ?? '');
                         ?>
                             <tr class="bpb-branch-row">
-                                <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه (Button)</th>
+                                <th><span class="dashicons dashicons-move" style="cursor:move;"></span> <?php echo esc_html(bpb_t('دکمه', 'Button', 'Schaltfläche')); ?></th>
                                 <td>
-                                    نام (Name): <input type="text" name="bpb_settings[contacts][<?php echo $i ?>][label]" value="<?php echo esc_attr($contact['label']) ?>" />
+                                    <?php echo esc_html(bpb_t('نام', 'Name', 'Name')); ?>: <input type="text" name="bpb_settings[contacts][<?php echo $i ?>][label]" value="<?php echo esc_attr($contact['label']) ?>" />
 
-                                    نوع اتصال (Connection Type / Verbindungstyp):
+                                    <?php echo esc_html(bpb_t('نوع اتصال', 'Connection Type', 'Verbindungstyp')); ?>:
                                     <select name="bpb_settings[contacts][<?php echo $i ?>][type]">
-                                        <option value="tel" <?php selected($type, 'tel'); ?>>تلفن (Phone / Telefon)</option>
-                                        <option value="mailto" <?php selected($type, 'mailto'); ?>>ایمیل (Email / E-Mail)</option>
-                                        <option value="whatsapp" <?php selected($type, 'whatsapp'); ?>>واتس‌اپ (WhatsApp)</option>
-                                        <option value="telegram" <?php selected($type, 'telegram'); ?>>تلگرام (Telegram)</option>
-                                        <option value="link" <?php selected($type, 'link'); ?>>لینک دلخواه (Custom Link / Benutzerdefinierter Link)</option>
+                                        <option value="tel" <?php selected($type, 'tel'); ?>><?php echo esc_html(bpb_t('تلفن', 'Phone', 'Telefon')); ?></option>
+                                        <option value="mailto" <?php selected($type, 'mailto'); ?>><?php echo esc_html(bpb_t('ایمیل', 'Email', 'E-Mail')); ?></option>
+                                        <option value="whatsapp" <?php selected($type, 'whatsapp'); ?>><?php echo esc_html(bpb_t('واتس‌اپ', 'WhatsApp', 'WhatsApp')); ?></option>
+                                        <option value="telegram" <?php selected($type, 'telegram'); ?>><?php echo esc_html(bpb_t('تلگرام', 'Telegram', 'Telegram')); ?></option>
+                                        <option value="link" <?php selected($type, 'link'); ?>><?php echo esc_html(bpb_t('لینک دلخواه', 'Custom Link', 'Benutzerdefinierter Link')); ?></option>
                                     </select>
 
-                                    مقدار (Value / Wert): <input type="text" name="bpb_settings[contacts][<?php echo $i ?>][value]" value="<?php echo esc_attr($val) ?>" />
+                                    <?php echo esc_html(bpb_t('مقدار', 'Value', 'Wert')); ?>: <input type="text" name="bpb_settings[contacts][<?php echo $i ?>][value]" value="<?php echo esc_attr($val) ?>" />
 
-                                    آیکون (Icon / Symbol):
+                                    <?php echo esc_html(bpb_t('آیکون', 'Icon', 'Symbol')); ?>:
                                     <select name="bpb_settings[contacts][<?php echo $i ?>][icon]">
-                                        <option value="phone" <?php selected($icon, 'phone'); ?>>تلفن (Phone / Telefon)</option>
-                                        <option value="email" <?php selected($icon, 'email'); ?>>ایمیل (Email / E-Mail)</option>
-                                        <option value="whatsapp" <?php selected($icon, 'whatsapp'); ?>>واتس‌اپ (WhatsApp)</option>
-                                        <option value="telegram" <?php selected($icon, 'telegram'); ?>>تلگرام (Telegram)</option>
-                                        <option value="link" <?php selected($icon, 'link'); ?>>لینک (Link)</option>
+                                        <option value="phone" <?php selected($icon, 'phone'); ?>><?php echo esc_html(bpb_t('تلفن', 'Phone', 'Telefon')); ?></option>
+                                        <option value="email" <?php selected($icon, 'email'); ?>><?php echo esc_html(bpb_t('ایمیل', 'Email', 'E-Mail')); ?></option>
+                                        <option value="whatsapp" <?php selected($icon, 'whatsapp'); ?>><?php echo esc_html(bpb_t('واتس‌اپ', 'WhatsApp', 'WhatsApp')); ?></option>
+                                        <option value="telegram" <?php selected($icon, 'telegram'); ?>><?php echo esc_html(bpb_t('تلگرام', 'Telegram', 'Telegram')); ?></option>
+                                        <option value="link" <?php selected($icon, 'link'); ?>><?php echo esc_html(bpb_t('لینک', 'Link', 'Link')); ?></option>
                                     </select>
 
-                                    زمان نمایش (Display Time / Anzeigezeit):
+                                    <?php echo esc_html(bpb_t('زمان نمایش', 'Display Time', 'Anzeigezeit')); ?>:
                                     <select name="bpb_settings[contacts][<?php echo $i ?>][timing]">
-                                        <option value="always" <?php selected($timing, 'always'); ?>>همیشه (Always / Immer)</option>
-                                        <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>>فقط در ساعات کاری (Business Hours Only / Nur Geschäftszeiten)</option>
-                                        <option value="off_hours" <?php selected($timing, 'off_hours'); ?>>فقط خارج از ساعات کاری (Off Hours Only / Nur außerhalb der Geschäftszeiten)</option>
+                                        <option value="always" <?php selected($timing, 'always'); ?>><?php echo esc_html(bpb_t('همیشه', 'Always', 'Immer')); ?></option>
+                                        <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>><?php echo esc_html(bpb_t('فقط در ساعات کاری', 'Business Hours Only', 'Nur Geschäftszeiten')); ?></option>
+                                        <option value="off_hours" <?php selected($timing, 'off_hours'); ?>><?php echo esc_html(bpb_t('فقط خارج از ساعات کاری', 'Off Hours Only', 'Nur außerhalb der Geschäftszeiten')); ?></option>
                                     </select>
 
-                                    رنگ (Color / Farbe): <input type="text" class="bpb-color-picker" name="bpb_settings[contacts][<?php echo $i ?>][color]" value="<?php echo esc_attr($contact['color']) ?>" />
-                                    سایز فونت (Font Size / Schriftgröße): <input type="number" name="bpb_settings[contacts][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($contact['font_size'] ?? 14) ?>" style="width: 60px;" />
+                                    <?php echo esc_html(bpb_t('رنگ', 'Color', 'Farbe')); ?>: <input type="text" class="bpb-color-picker" name="bpb_settings[contacts][<?php echo $i ?>][color]" value="<?php echo esc_attr($contact['color']) ?>" />
+                                    <?php echo esc_html(bpb_t('سایز فونت', 'Font Size', 'Schriftgröße')); ?>: <input type="number" name="bpb_settings[contacts][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($contact['font_size'] ?? 14) ?>" style="width: 60px;" />
 
-                                    <button type="button" class="button bpb-remove-row">حذف (Remove / Entfernen)</button>
+                                    <button type="button" class="button bpb-remove-row"><?php echo esc_html(bpb_t('حذف', 'Remove', 'Entfernen')); ?></button>
 
                                     <input type="hidden" name="bpb_settings[contacts][<?php echo $i ?>][order]" value="<?php echo $i ?>" class="bpb-order-field">
                                 </td>
@@ -201,24 +218,24 @@ function bpb_render_settings_page() {
                         <?php endforeach; ?>
                     </tbody>
                 </table>
-                <p><button type="button" id="bpb-add-contact-row" class="button bpb-add-row" data-target="contacts">افزودن دکمه جدید (راه‌های ارتباطی) - Add New Contact Button - Neuen Kontakt-Button hinzufügen</button></p>
+                <p><button type="button" id="bpb-add-contact-row" class="button bpb-add-row" data-target="contacts"><?php echo esc_html(bpb_t('افزودن دکمه جدید (راه‌های ارتباطی)', 'Add New Contact Button', 'Neuen Kontakt-Button hinzufügen')); ?></button></p>
             </div>
 
-            <input type="submit" name="bpb_save" class="button button-primary" value="ذخیره تنظیمات (Save Settings / Einstellungen speichern)">
+            <input type="submit" name="bpb_save" class="button button-primary" value="<?php echo esc_attr(bpb_t('ذخیره تنظیمات', 'Save Settings', 'Einstellungen speichern')); ?>">
         </form>
 
         <hr>
-        <h2>آمار کلیک‌ها (داخلی) - Click Stats (Internal) - Klickstatistiken (Intern)</h2>
+        <h2><?php echo esc_html(bpb_t('آمار کلیک‌ها (داخلی)', 'Click Stats (Internal)', 'Klickstatistiken (Intern)')); ?></h2>
         <table class="widefat striped" style="max-width: 400px;">
             <thead>
                 <tr>
-                    <th>نام دکمه (Button Name / Button-Name)</th>
-                    <th>تعداد کلیک (Clicks / Klicks)</th>
+                    <th><?php echo esc_html(bpb_t('نام دکمه', 'Button Name', 'Button-Name')); ?></th>
+                    <th><?php echo esc_html(bpb_t('تعداد کلیک', 'Clicks', 'Klicks')); ?></th>
                 </tr>
             </thead>
             <tbody>
                 <?php if (empty($stats)): ?>
-                    <tr><td colspan="2">هنوز هیچ کلیکی ثبت نشده است. (No clicks recorded yet. / Noch keine Klicks verzeichnet.)</td></tr>
+                    <tr><td colspan="2"><?php echo esc_html(bpb_t('هنوز هیچ کلیکی ثبت نشده است.', 'No clicks recorded yet.', 'Noch keine Klicks verzeichnet.')); ?></td></tr>
                 <?php else: ?>
                     <?php foreach ($stats as $lbl => $count): ?>
                         <tr>
@@ -230,13 +247,36 @@ function bpb_render_settings_page() {
             </tbody>
         </table>
         <br>
-        <form method="post" onsubmit="return confirm('آیا از پاک شدن آمار مطمئن هستید؟ (Are you sure you want to clear the stats? / Sind Sie sicher, dass Sie die Statistiken löschen möchten?)');">
+        <form method="post" onsubmit="return confirm('<?php echo esc_js(bpb_t('آیا از پاک شدن آمار مطمئن هستید؟', 'Are you sure you want to clear the stats?', 'Sind Sie sicher, dass Sie die Statistiken löschen möchten?')); ?>');">
             <?php wp_nonce_field('bpb_settings_action', 'bpb_settings_nonce'); ?>
-            <input type="submit" name="bpb_reset_stats" class="button button-secondary" value="بازنشانی آمار (Reset Stats / Statistiken zurücksetzen)">
+            <input type="submit" name="bpb_reset_stats" class="button button-secondary" value="<?php echo esc_attr(bpb_t('بازنشانی آمار', 'Reset Stats', 'Statistiken zurücksetzen')); ?>">
         </form>
 
         <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.14.0/Sortable.min.js"></script>
         <script>
+            // Translation strings for JS
+            var bpb_i18n = {
+                btn_new: '<?php echo esc_js(bpb_t("جدید", "New", "Neu")); ?>',
+                btn_label: '<?php echo esc_js(bpb_t("دکمه", "Button", "Schaltfläche")); ?>',
+                name: '<?php echo esc_js(bpb_t("نام", "Name", "Name")); ?>',
+                conn_type: '<?php echo esc_js(bpb_t("نوع اتصال", "Connection Type", "Verbindungstyp")); ?>',
+                phone: '<?php echo esc_js(bpb_t("تلفن", "Phone", "Telefon")); ?>',
+                email: '<?php echo esc_js(bpb_t("ایمیل", "Email", "E-Mail")); ?>',
+                whatsapp: '<?php echo esc_js(bpb_t("واتس‌اپ", "WhatsApp", "WhatsApp")); ?>',
+                telegram: '<?php echo esc_js(bpb_t("تلگرام", "Telegram", "Telegram")); ?>',
+                custom_link: '<?php echo esc_js(bpb_t("لینک دلخواه", "Custom Link", "Benutzerdefinierter Link")); ?>',
+                value: '<?php echo esc_js(bpb_t("مقدار", "Value", "Wert")); ?>',
+                icon: '<?php echo esc_js(bpb_t("آیکون", "Icon", "Symbol")); ?>',
+                link: '<?php echo esc_js(bpb_t("لینک", "Link", "Link")); ?>',
+                display_time: '<?php echo esc_js(bpb_t("زمان نمایش", "Display Time", "Anzeigezeit")); ?>',
+                always: '<?php echo esc_js(bpb_t("همیشه", "Always", "Immer")); ?>',
+                biz_hours: '<?php echo esc_js(bpb_t("فقط در ساعات کاری", "Business Hours Only", "Nur Geschäftszeiten")); ?>',
+                off_hours: '<?php echo esc_js(bpb_t("فقط خارج از ساعات کاری", "Off Hours Only", "Nur außerhalb der Geschäftszeiten")); ?>',
+                color: '<?php echo esc_js(bpb_t("رنگ", "Color", "Farbe")); ?>',
+                font_size: '<?php echo esc_js(bpb_t("سایز فونت", "Font Size", "Schriftgröße")); ?>',
+                remove: '<?php echo esc_js(bpb_t("حذف", "Remove", "Entfernen")); ?>'
+            };
+
             jQuery(document).ready(function($){
                 // Mode switcher
                 function updateModeDisplay() {
@@ -285,41 +325,41 @@ function bpb_render_settings_page() {
 
                     var html = `
                         <tr class="bpb-branch-row">
-                            <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه (Button)</th>
+                            <th><span class="dashicons dashicons-move" style="cursor:move;"></span> ${bpb_i18n.btn_label}</th>
                             <td>
-                                نام (Name): <input type="text" name="bpb_settings[${target}][${newIndex}][label]" value="جدید (New/Neu)" />
+                                ${bpb_i18n.name}: <input type="text" name="bpb_settings[${target}][${newIndex}][label]" value="${bpb_i18n.btn_new}" />
 
-                                نوع اتصال (Connection Type / Verbindungstyp):
+                                ${bpb_i18n.conn_type}:
                                 <select name="bpb_settings[${target}][${newIndex}][type]">
-                                    <option value="tel">تلفن (Phone / Telefon)</option>
-                                    <option value="mailto">ایمیل (Email / E-Mail)</option>
-                                    <option value="whatsapp">واتس‌اپ (WhatsApp)</option>
-                                    <option value="telegram">تلگرام (Telegram)</option>
-                                    <option value="link">لینک دلخواه (Custom Link / Benutzerdefinierter Link)</option>
+                                    <option value="tel">${bpb_i18n.phone}</option>
+                                    <option value="mailto">${bpb_i18n.email}</option>
+                                    <option value="whatsapp">${bpb_i18n.whatsapp}</option>
+                                    <option value="telegram">${bpb_i18n.telegram}</option>
+                                    <option value="link">${bpb_i18n.custom_link}</option>
                                 </select>
 
-                                مقدار (Value / Wert): <input type="text" name="bpb_settings[${target}][${newIndex}][value]" value="" />
+                                ${bpb_i18n.value}: <input type="text" name="bpb_settings[${target}][${newIndex}][value]" value="" />
 
-                                آیکون (Icon / Symbol):
+                                ${bpb_i18n.icon}:
                                 <select name="bpb_settings[${target}][${newIndex}][icon]">
-                                    <option value="phone">تلفن (Phone / Telefon)</option>
-                                    <option value="email">ایمیل (Email / E-Mail)</option>
-                                    <option value="whatsapp">واتس‌اپ (WhatsApp)</option>
-                                    <option value="telegram">تلگرام (Telegram)</option>
-                                    <option value="link">لینک (Link)</option>
+                                    <option value="phone">${bpb_i18n.phone}</option>
+                                    <option value="email">${bpb_i18n.email}</option>
+                                    <option value="whatsapp">${bpb_i18n.whatsapp}</option>
+                                    <option value="telegram">${bpb_i18n.telegram}</option>
+                                    <option value="link">${bpb_i18n.link}</option>
                                 </select>
 
-                                زمان نمایش (Display Time / Anzeigezeit):
+                                ${bpb_i18n.display_time}:
                                 <select name="bpb_settings[${target}][${newIndex}][timing]">
-                                    <option value="always">همیشه (Always / Immer)</option>
-                                    <option value="biz_hours">فقط در ساعات کاری (Business Hours Only / Nur Geschäftszeiten)</option>
-                                    <option value="off_hours">فقط خارج از ساعات کاری (Off Hours Only / Nur außerhalb der Geschäftszeiten)</option>
+                                    <option value="always">${bpb_i18n.always}</option>
+                                    <option value="biz_hours">${bpb_i18n.biz_hours}</option>
+                                    <option value="off_hours">${bpb_i18n.off_hours}</option>
                                 </select>
 
-                                رنگ (Color / Farbe): <input type="text" class="bpb-color-picker" name="bpb_settings[${target}][${newIndex}][color]" value="#000000" />
-                                سایز فونت (Font Size / Schriftgröße): <input type="number" name="bpb_settings[${target}][${newIndex}][font_size]" value="14" style="width: 60px;" />
+                                ${bpb_i18n.color}: <input type="text" class="bpb-color-picker" name="bpb_settings[${target}][${newIndex}][color]" value="#000000" />
+                                ${bpb_i18n.font_size}: <input type="number" name="bpb_settings[${target}][${newIndex}][font_size]" value="14" style="width: 60px;" />
 
-                                <button type="button" class="button bpb-remove-row">حذف (Remove / Entfernen)</button>
+                                <button type="button" class="button bpb-remove-row">${bpb_i18n.remove}</button>
 
                                 <input type="hidden" name="bpb_settings[${target}][${newIndex}][order]" value="${newIndex}" class="bpb-order-field">
                             </td>
@@ -341,7 +381,7 @@ function bpb_render_settings_page() {
         </script>
         <hr>
         <div style="background:#fef3c7; padding:15px; border:1px solid #fcd34d;">
-            <strong>تبلیغ ویژه (Special Offer / Sonderangebot):</strong> اجرای کمپین گوگل ادز برای کسب‌وکار شما با سایت با ما - <a href="https://siteebama.com" target="_blank">اطلاعات بیشتر (More info / Weitere Informationen)</a>
+            <strong><?php echo esc_html(bpb_t('تبلیغ ویژه', 'Special Offer', 'Sonderangebot')); ?>:</strong> <?php echo esc_html(bpb_t('اجرای کمپین گوگل ادز برای کسب‌وکار شما با سایت با ما', 'Run Google Ads campaigns for your business with SiteBaMa', 'Führen Sie Google Ads-Kampagnen für Ihr Unternehmen mit SiteBaMa durch')); ?> - <a href="https://siteebama.com" target="_blank"><?php echo esc_html(bpb_t('اطلاعات بیشتر', 'More info', 'Weitere Informationen')); ?></a>
         </div>
     </div>
     <?php

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -2,84 +2,84 @@
 if (!defined('ABSPATH')) exit;
 
 add_action('admin_menu', function() {
-    add_menu_page('تنظیمات دکمه تماس', 'تماس شعب', 'manage_options', 'bpb-settings', 'bpb_render_settings_page');
+    add_menu_page('تنظیمات دکمه تماس (Call Button Settings / Anruf-Button-Einstellungen)', 'تماس شعب (Branch Contact / Filialkontakt)', 'manage_options', 'bpb-settings', 'bpb_render_settings_page');
 });
 
 function bpb_render_settings_page() {
     if (isset($_POST['bpb_save']) && check_admin_referer('bpb_settings_action', 'bpb_settings_nonce')) {
         update_option('bpb_settings', $_POST['bpb_settings']);
-        echo '<div class="updated"><p>تنظیمات ذخیره شد.</p></div>';
+        echo '<div class="updated"><p>تنظیمات ذخیره شد. (Settings saved. / Einstellungen gespeichert.)</p></div>';
     }
 
     if (isset($_POST['bpb_reset_stats']) && check_admin_referer('bpb_settings_action', 'bpb_settings_nonce')) {
         update_option('bpb_click_stats', []);
-        echo '<div class="updated"><p>آمار کلیک‌ها بازنشانی شد.</p></div>';
+        echo '<div class="updated"><p>آمار کلیک‌ها بازنشانی شد. (Click stats reset. / Klickstatistiken zurückgesetzt.)</p></div>';
     }
 
     $settings = get_option('bpb_settings', bpb_default_settings());
     $stats = get_option('bpb_click_stats', []);
     ?>
     <div class="wrap">
-        <h1>تنظیمات دکمه تماس شعب (نسخه 1.2)</h1>
+        <h1>تنظیمات دکمه تماس شعب (Branch Phone Button Settings / Filial-Anruf-Button-Einstellungen) - نسخه 1.2</h1>
         <form method="post">
             <?php wp_nonce_field('bpb_settings_action', 'bpb_settings_nonce'); ?>
             <table class="form-table">
                 <tr>
-                    <th scope="row">حالت نمایش</th>
+                    <th scope="row">حالت نمایش (Display Mode / Anzeigemodus)</th>
                     <td>
                         <label>
                             <input type="radio" name="bpb_settings[mode]" value="branches" <?php checked($settings['mode'] ?? 'branches', 'branches'); ?>>
-                            حالت شعب (چند شعبه)
+                            حالت شعب (چند شعبه) - Branches Mode (Multiple Branches) - Filialmodus (Mehrere Filialen)
                         </label><br>
                         <label>
                             <input type="radio" name="bpb_settings[mode]" value="contacts" <?php checked($settings['mode'] ?? 'branches', 'contacts'); ?>>
-                            حالت راه‌های ارتباطی (تماس، ایمیل و ...)
+                            حالت راه‌های ارتباطی (تماس، ایمیل و ...) - Contacts Mode (Call, Email, etc.) - Kontaktmodus (Anruf, E-Mail usw.)
                         </label>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">تأخیر نمایش (ثانیه)</th>
+                    <th scope="row">تأخیر نمایش (ثانیه) <br>(Display Delay (sec) / Anzeigeverzögerung (Sek.))</th>
                     <td>
                         <input type="number" name="bpb_settings[delay]" value="<?php echo esc_attr($settings['delay'] ?? 0); ?>" min="0" />
-                        <p class="description">تعداد ثانیه‌هایی که طول می‌کشد تا دکمه‌ها نمایش داده شوند. 0 برای نمایش فوری.</p>
+                        <p class="description">تعداد ثانیه‌هایی که طول می‌کشد تا دکمه‌ها نمایش داده شوند. 0 برای نمایش فوری.<br>(Seconds until buttons are displayed. 0 for instant display. / Sekunden bis die Schaltflächen angezeigt werden. 0 für sofortige Anzeige.)</p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">نحوه نمایش</th>
+                    <th scope="row">نحوه نمایش (Display Style / Anzeigestil)</th>
                     <td>
                         <select name="bpb_settings[display_style]">
-                            <option value="flat" <?php selected($settings['display_style'] ?? 'flat', 'flat'); ?>>چسبیده به پایین (کامل)</option>
-                            <option value="floating" <?php selected($settings['display_style'] ?? 'flat', 'floating'); ?>>شناور (گرد)</option>
+                            <option value="flat" <?php selected($settings['display_style'] ?? 'flat', 'flat'); ?>>چسبیده به پایین (کامل) - Sticky Bottom (Full) - Unten anheften (Vollständig)</option>
+                            <option value="floating" <?php selected($settings['display_style'] ?? 'flat', 'floating'); ?>>شناور (گرد) - Floating (Round) - Schwebend (Rund)</option>
                         </select>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">قوانین نمایش (صفحات)</th>
+                    <th scope="row">قوانین نمایش (صفحات) <br>(Display Rules (Pages) / Anzeigeregeln (Seiten))</th>
                     <td>
                         <label>
                             <input type="checkbox" name="bpb_settings[show_only_homepage]" value="1" <?php checked($settings['show_only_homepage'] ?? 0, 1); ?>>
-                            فقط در صفحه اصلی نمایش داده شود
+                            فقط در صفحه اصلی نمایش داده شود (Show only on homepage / Nur auf der Startseite anzeigen)
                         </label><br>
                         <label>
                             <input type="checkbox" name="bpb_settings[hide_on_woo_checkout]" value="1" <?php checked($settings['hide_on_woo_checkout'] ?? 0, 1); ?>>
-                            عدم نمایش در صفحه سبد خرید و پرداخت ووکامرس
+                            عدم نمایش در صفحه سبد خرید و پرداخت ووکامرس (Hide on WooCommerce Cart & Checkout / Ausblenden auf WooCommerce Warenkorb & Kasse)
                         </label>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">ساعات کاری اداری</th>
+                    <th scope="row">ساعات کاری اداری <br>(Business Hours / Geschäftszeiten)</th>
                     <td>
-                        از <input type="time" name="bpb_settings[biz_time_start]" value="<?php echo esc_attr($settings['biz_time_start'] ?? '08:00'); ?>" />
-                        تا <input type="time" name="bpb_settings[biz_time_end]" value="<?php echo esc_attr($settings['biz_time_end'] ?? '17:00'); ?>" />
-                        <p class="description">بر اساس منطقه زمانی وردپرس (تنظیمات > عمومی). می‌توانید دکمه‌ها را محدود به این ساعات کنید.</p>
+                        از (From / Von) <input type="time" name="bpb_settings[biz_time_start]" value="<?php echo esc_attr($settings['biz_time_start'] ?? '08:00'); ?>" />
+                        تا (To / Bis) <input type="time" name="bpb_settings[biz_time_end]" value="<?php echo esc_attr($settings['biz_time_end'] ?? '17:00'); ?>" />
+                        <p class="description">بر اساس منطقه زمانی وردپرس (تنظیمات > عمومی). می‌توانید دکمه‌ها را محدود به این ساعات کنید.<br>(Based on WordPress timezone (Settings > General). You can limit buttons to these hours. / Basierend auf der WordPress-Zeitzone (Einstellungen > Allgemein). Sie können die Schaltflächen auf diese Zeiten beschränken.)</p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">رهگیری آمار (Analytics)</th>
+                    <th scope="row">رهگیری آمار <br>(Analytics Tracking / Analyse-Tracking)</th>
                     <td>
                         <label>
                             <input type="checkbox" name="bpb_settings[enable_ga_tracking]" value="1" <?php checked($settings['enable_ga_tracking'] ?? 0, 1); ?>>
-                            ثبت کلیک‌ها در گوگل آنالیتیکس (Gtag)
+                            ثبت کلیک‌ها در گوگل آنالیتیکس (Log clicks in Google Analytics (Gtag) / Klicks in Google Analytics erfassen (Gtag))
                         </label>
                     </td>
                 </tr>
@@ -88,7 +88,7 @@ function bpb_render_settings_page() {
             <hr>
 
             <div id="bpb-branches-wrapper">
-                <h2>دکمه‌های حالت شعب</h2>
+                <h2>دکمه‌های حالت شعب (Branch Mode Buttons / Schaltflächen für den Filialmodus)</h2>
                 <table class="form-table" id="bpb-branches-table">
                     <tbody>
                         <?php
@@ -101,41 +101,41 @@ function bpb_render_settings_page() {
                             $val = $branch['value'] ?? ($branch['phone'] ?? '');
                         ?>
                             <tr class="bpb-branch-row">
-                                <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه</th>
+                                <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه (Button)</th>
                                 <td>
-                                    نام: <input type="text" name="bpb_settings[branches][<?php echo $i ?>][label]" value="<?php echo esc_attr($branch['label']) ?>" />
+                                    نام (Name): <input type="text" name="bpb_settings[branches][<?php echo $i ?>][label]" value="<?php echo esc_attr($branch['label']) ?>" />
 
-                                    نوع اتصال:
+                                    نوع اتصال (Connection Type / Verbindungstyp):
                                     <select name="bpb_settings[branches][<?php echo $i ?>][type]">
-                                        <option value="tel" <?php selected($type, 'tel'); ?>>تلفن</option>
-                                        <option value="mailto" <?php selected($type, 'mailto'); ?>>ایمیل</option>
-                                        <option value="whatsapp" <?php selected($type, 'whatsapp'); ?>>واتس‌اپ</option>
-                                        <option value="telegram" <?php selected($type, 'telegram'); ?>>تلگرام</option>
-                                        <option value="link" <?php selected($type, 'link'); ?>>لینک دلخواه</option>
+                                        <option value="tel" <?php selected($type, 'tel'); ?>>تلفن (Phone / Telefon)</option>
+                                        <option value="mailto" <?php selected($type, 'mailto'); ?>>ایمیل (Email / E-Mail)</option>
+                                        <option value="whatsapp" <?php selected($type, 'whatsapp'); ?>>واتس‌اپ (WhatsApp)</option>
+                                        <option value="telegram" <?php selected($type, 'telegram'); ?>>تلگرام (Telegram)</option>
+                                        <option value="link" <?php selected($type, 'link'); ?>>لینک دلخواه (Custom Link / Benutzerdefinierter Link)</option>
                                     </select>
 
-                                    مقدار (شماره/لینک): <input type="text" name="bpb_settings[branches][<?php echo $i ?>][value]" value="<?php echo esc_attr($val) ?>" />
+                                    مقدار (Value / Wert): <input type="text" name="bpb_settings[branches][<?php echo $i ?>][value]" value="<?php echo esc_attr($val) ?>" />
 
-                                    آیکون:
+                                    آیکون (Icon / Symbol):
                                     <select name="bpb_settings[branches][<?php echo $i ?>][icon]">
-                                        <option value="phone" <?php selected($icon, 'phone'); ?>>تلفن</option>
-                                        <option value="email" <?php selected($icon, 'email'); ?>>ایمیل</option>
-                                        <option value="whatsapp" <?php selected($icon, 'whatsapp'); ?>>واتس‌اپ</option>
-                                        <option value="telegram" <?php selected($icon, 'telegram'); ?>>تلگرام</option>
-                                        <option value="link" <?php selected($icon, 'link'); ?>>لینک</option>
+                                        <option value="phone" <?php selected($icon, 'phone'); ?>>تلفن (Phone / Telefon)</option>
+                                        <option value="email" <?php selected($icon, 'email'); ?>>ایمیل (Email / E-Mail)</option>
+                                        <option value="whatsapp" <?php selected($icon, 'whatsapp'); ?>>واتس‌اپ (WhatsApp)</option>
+                                        <option value="telegram" <?php selected($icon, 'telegram'); ?>>تلگرام (Telegram)</option>
+                                        <option value="link" <?php selected($icon, 'link'); ?>>لینک (Link)</option>
                                     </select>
 
-                                    زمان نمایش:
+                                    زمان نمایش (Display Time / Anzeigezeit):
                                     <select name="bpb_settings[branches][<?php echo $i ?>][timing]">
-                                        <option value="always" <?php selected($timing, 'always'); ?>>همیشه</option>
-                                        <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>>فقط در ساعات کاری</option>
-                                        <option value="off_hours" <?php selected($timing, 'off_hours'); ?>>فقط خارج از ساعات کاری</option>
+                                        <option value="always" <?php selected($timing, 'always'); ?>>همیشه (Always / Immer)</option>
+                                        <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>>فقط در ساعات کاری (Business Hours Only / Nur Geschäftszeiten)</option>
+                                        <option value="off_hours" <?php selected($timing, 'off_hours'); ?>>فقط خارج از ساعات کاری (Off Hours Only / Nur außerhalb der Geschäftszeiten)</option>
                                     </select>
 
-                                    رنگ: <input type="text" class="bpb-color-picker" name="bpb_settings[branches][<?php echo $i ?>][color]" value="<?php echo esc_attr($branch['color']) ?>" />
-                                    سایز فونت: <input type="number" name="bpb_settings[branches][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($branch['font_size'] ?? 14) ?>" style="width: 60px;" />
+                                    رنگ (Color / Farbe): <input type="text" class="bpb-color-picker" name="bpb_settings[branches][<?php echo $i ?>][color]" value="<?php echo esc_attr($branch['color']) ?>" />
+                                    سایز فونت (Font Size / Schriftgröße): <input type="number" name="bpb_settings[branches][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($branch['font_size'] ?? 14) ?>" style="width: 60px;" />
 
-                                    <button type="button" class="button bpb-remove-row">حذف</button>
+                                    <button type="button" class="button bpb-remove-row">حذف (Remove / Entfernen)</button>
 
                                     <input type="hidden" name="bpb_settings[branches][<?php echo $i ?>][order]" value="<?php echo $i ?>" class="bpb-order-field">
                                 </td>
@@ -143,11 +143,11 @@ function bpb_render_settings_page() {
                         <?php endforeach; ?>
                     </tbody>
                 </table>
-                <p><button type="button" id="bpb-add-branch-row" class="button bpb-add-row" data-target="branches">افزودن دکمه جدید (شعب)</button></p>
+                <p><button type="button" id="bpb-add-branch-row" class="button bpb-add-row" data-target="branches">افزودن دکمه جدید (شعب) - Add New Branch Button - Neuen Filial-Button hinzufügen</button></p>
             </div>
 
             <div id="bpb-contacts-wrapper">
-                <h2>دکمه‌های حالت راه‌های ارتباطی</h2>
+                <h2>دکمه‌های حالت راه‌های ارتباطی (Contacts Mode Buttons / Schaltflächen für den Kontaktmodus)</h2>
                 <table class="form-table" id="bpb-contacts-table">
                     <tbody>
                         <?php
@@ -159,41 +159,41 @@ function bpb_render_settings_page() {
                             $val = $contact['value'] ?? ($contact['phone'] ?? '');
                         ?>
                             <tr class="bpb-branch-row">
-                                <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه</th>
+                                <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه (Button)</th>
                                 <td>
-                                    نام: <input type="text" name="bpb_settings[contacts][<?php echo $i ?>][label]" value="<?php echo esc_attr($contact['label']) ?>" />
+                                    نام (Name): <input type="text" name="bpb_settings[contacts][<?php echo $i ?>][label]" value="<?php echo esc_attr($contact['label']) ?>" />
 
-                                    نوع اتصال:
+                                    نوع اتصال (Connection Type / Verbindungstyp):
                                     <select name="bpb_settings[contacts][<?php echo $i ?>][type]">
-                                        <option value="tel" <?php selected($type, 'tel'); ?>>تلفن</option>
-                                        <option value="mailto" <?php selected($type, 'mailto'); ?>>ایمیل</option>
-                                        <option value="whatsapp" <?php selected($type, 'whatsapp'); ?>>واتس‌اپ</option>
-                                        <option value="telegram" <?php selected($type, 'telegram'); ?>>تلگرام</option>
-                                        <option value="link" <?php selected($type, 'link'); ?>>لینک دلخواه</option>
+                                        <option value="tel" <?php selected($type, 'tel'); ?>>تلفن (Phone / Telefon)</option>
+                                        <option value="mailto" <?php selected($type, 'mailto'); ?>>ایمیل (Email / E-Mail)</option>
+                                        <option value="whatsapp" <?php selected($type, 'whatsapp'); ?>>واتس‌اپ (WhatsApp)</option>
+                                        <option value="telegram" <?php selected($type, 'telegram'); ?>>تلگرام (Telegram)</option>
+                                        <option value="link" <?php selected($type, 'link'); ?>>لینک دلخواه (Custom Link / Benutzerdefinierter Link)</option>
                                     </select>
 
-                                    مقدار (شماره/لینک): <input type="text" name="bpb_settings[contacts][<?php echo $i ?>][value]" value="<?php echo esc_attr($val) ?>" />
+                                    مقدار (Value / Wert): <input type="text" name="bpb_settings[contacts][<?php echo $i ?>][value]" value="<?php echo esc_attr($val) ?>" />
 
-                                    آیکون:
+                                    آیکون (Icon / Symbol):
                                     <select name="bpb_settings[contacts][<?php echo $i ?>][icon]">
-                                        <option value="phone" <?php selected($icon, 'phone'); ?>>تلفن</option>
-                                        <option value="email" <?php selected($icon, 'email'); ?>>ایمیل</option>
-                                        <option value="whatsapp" <?php selected($icon, 'whatsapp'); ?>>واتس‌اپ</option>
-                                        <option value="telegram" <?php selected($icon, 'telegram'); ?>>تلگرام</option>
-                                        <option value="link" <?php selected($icon, 'link'); ?>>لینک</option>
+                                        <option value="phone" <?php selected($icon, 'phone'); ?>>تلفن (Phone / Telefon)</option>
+                                        <option value="email" <?php selected($icon, 'email'); ?>>ایمیل (Email / E-Mail)</option>
+                                        <option value="whatsapp" <?php selected($icon, 'whatsapp'); ?>>واتس‌اپ (WhatsApp)</option>
+                                        <option value="telegram" <?php selected($icon, 'telegram'); ?>>تلگرام (Telegram)</option>
+                                        <option value="link" <?php selected($icon, 'link'); ?>>لینک (Link)</option>
                                     </select>
 
-                                    زمان نمایش:
+                                    زمان نمایش (Display Time / Anzeigezeit):
                                     <select name="bpb_settings[contacts][<?php echo $i ?>][timing]">
-                                        <option value="always" <?php selected($timing, 'always'); ?>>همیشه</option>
-                                        <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>>فقط در ساعات کاری</option>
-                                        <option value="off_hours" <?php selected($timing, 'off_hours'); ?>>فقط خارج از ساعات کاری</option>
+                                        <option value="always" <?php selected($timing, 'always'); ?>>همیشه (Always / Immer)</option>
+                                        <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>>فقط در ساعات کاری (Business Hours Only / Nur Geschäftszeiten)</option>
+                                        <option value="off_hours" <?php selected($timing, 'off_hours'); ?>>فقط خارج از ساعات کاری (Off Hours Only / Nur außerhalb der Geschäftszeiten)</option>
                                     </select>
 
-                                    رنگ: <input type="text" class="bpb-color-picker" name="bpb_settings[contacts][<?php echo $i ?>][color]" value="<?php echo esc_attr($contact['color']) ?>" />
-                                    سایز فونت: <input type="number" name="bpb_settings[contacts][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($contact['font_size'] ?? 14) ?>" style="width: 60px;" />
+                                    رنگ (Color / Farbe): <input type="text" class="bpb-color-picker" name="bpb_settings[contacts][<?php echo $i ?>][color]" value="<?php echo esc_attr($contact['color']) ?>" />
+                                    سایز فونت (Font Size / Schriftgröße): <input type="number" name="bpb_settings[contacts][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($contact['font_size'] ?? 14) ?>" style="width: 60px;" />
 
-                                    <button type="button" class="button bpb-remove-row">حذف</button>
+                                    <button type="button" class="button bpb-remove-row">حذف (Remove / Entfernen)</button>
 
                                     <input type="hidden" name="bpb_settings[contacts][<?php echo $i ?>][order]" value="<?php echo $i ?>" class="bpb-order-field">
                                 </td>
@@ -201,24 +201,24 @@ function bpb_render_settings_page() {
                         <?php endforeach; ?>
                     </tbody>
                 </table>
-                <p><button type="button" id="bpb-add-contact-row" class="button bpb-add-row" data-target="contacts">افزودن دکمه جدید (راه‌های ارتباطی)</button></p>
+                <p><button type="button" id="bpb-add-contact-row" class="button bpb-add-row" data-target="contacts">افزودن دکمه جدید (راه‌های ارتباطی) - Add New Contact Button - Neuen Kontakt-Button hinzufügen</button></p>
             </div>
 
-            <input type="submit" name="bpb_save" class="button button-primary" value="ذخیره تنظیمات">
+            <input type="submit" name="bpb_save" class="button button-primary" value="ذخیره تنظیمات (Save Settings / Einstellungen speichern)">
         </form>
 
         <hr>
-        <h2>آمار کلیک‌ها (داخلی)</h2>
+        <h2>آمار کلیک‌ها (داخلی) - Click Stats (Internal) - Klickstatistiken (Intern)</h2>
         <table class="widefat striped" style="max-width: 400px;">
             <thead>
                 <tr>
-                    <th>نام دکمه</th>
-                    <th>تعداد کلیک</th>
+                    <th>نام دکمه (Button Name / Button-Name)</th>
+                    <th>تعداد کلیک (Clicks / Klicks)</th>
                 </tr>
             </thead>
             <tbody>
                 <?php if (empty($stats)): ?>
-                    <tr><td colspan="2">هنوز هیچ کلیکی ثبت نشده است.</td></tr>
+                    <tr><td colspan="2">هنوز هیچ کلیکی ثبت نشده است. (No clicks recorded yet. / Noch keine Klicks verzeichnet.)</td></tr>
                 <?php else: ?>
                     <?php foreach ($stats as $lbl => $count): ?>
                         <tr>
@@ -230,9 +230,9 @@ function bpb_render_settings_page() {
             </tbody>
         </table>
         <br>
-        <form method="post" onsubmit="return confirm('آیا از پاک شدن آمار مطمئن هستید؟');">
+        <form method="post" onsubmit="return confirm('آیا از پاک شدن آمار مطمئن هستید؟ (Are you sure you want to clear the stats? / Sind Sie sicher, dass Sie die Statistiken löschen möchten?)');">
             <?php wp_nonce_field('bpb_settings_action', 'bpb_settings_nonce'); ?>
-            <input type="submit" name="bpb_reset_stats" class="button button-secondary" value="بازنشانی آمار">
+            <input type="submit" name="bpb_reset_stats" class="button button-secondary" value="بازنشانی آمار (Reset Stats / Statistiken zurücksetzen)">
         </form>
 
         <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.14.0/Sortable.min.js"></script>
@@ -285,41 +285,41 @@ function bpb_render_settings_page() {
 
                     var html = `
                         <tr class="bpb-branch-row">
-                            <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه</th>
+                            <th><span class="dashicons dashicons-move" style="cursor:move;"></span> دکمه (Button)</th>
                             <td>
-                                نام: <input type="text" name="bpb_settings[${target}][${newIndex}][label]" value="جدید" />
+                                نام (Name): <input type="text" name="bpb_settings[${target}][${newIndex}][label]" value="جدید (New/Neu)" />
 
-                                نوع اتصال:
+                                نوع اتصال (Connection Type / Verbindungstyp):
                                 <select name="bpb_settings[${target}][${newIndex}][type]">
-                                    <option value="tel">تلفن</option>
-                                    <option value="mailto">ایمیل</option>
-                                    <option value="whatsapp">واتس‌اپ</option>
-                                    <option value="telegram">تلگرام</option>
-                                    <option value="link">لینک دلخواه</option>
+                                    <option value="tel">تلفن (Phone / Telefon)</option>
+                                    <option value="mailto">ایمیل (Email / E-Mail)</option>
+                                    <option value="whatsapp">واتس‌اپ (WhatsApp)</option>
+                                    <option value="telegram">تلگرام (Telegram)</option>
+                                    <option value="link">لینک دلخواه (Custom Link / Benutzerdefinierter Link)</option>
                                 </select>
 
-                                مقدار (شماره/لینک): <input type="text" name="bpb_settings[${target}][${newIndex}][value]" value="" />
+                                مقدار (Value / Wert): <input type="text" name="bpb_settings[${target}][${newIndex}][value]" value="" />
 
-                                آیکون:
+                                آیکون (Icon / Symbol):
                                 <select name="bpb_settings[${target}][${newIndex}][icon]">
-                                    <option value="phone">تلفن</option>
-                                    <option value="email">ایمیل</option>
-                                    <option value="whatsapp">واتس‌اپ</option>
-                                    <option value="telegram">تلگرام</option>
-                                    <option value="link">لینک</option>
+                                    <option value="phone">تلفن (Phone / Telefon)</option>
+                                    <option value="email">ایمیل (Email / E-Mail)</option>
+                                    <option value="whatsapp">واتس‌اپ (WhatsApp)</option>
+                                    <option value="telegram">تلگرام (Telegram)</option>
+                                    <option value="link">لینک (Link)</option>
                                 </select>
 
-                                زمان نمایش:
+                                زمان نمایش (Display Time / Anzeigezeit):
                                 <select name="bpb_settings[${target}][${newIndex}][timing]">
-                                    <option value="always">همیشه</option>
-                                    <option value="biz_hours">فقط در ساعات کاری</option>
-                                    <option value="off_hours">فقط خارج از ساعات کاری</option>
+                                    <option value="always">همیشه (Always / Immer)</option>
+                                    <option value="biz_hours">فقط در ساعات کاری (Business Hours Only / Nur Geschäftszeiten)</option>
+                                    <option value="off_hours">فقط خارج از ساعات کاری (Off Hours Only / Nur außerhalb der Geschäftszeiten)</option>
                                 </select>
 
-                                رنگ: <input type="text" class="bpb-color-picker" name="bpb_settings[${target}][${newIndex}][color]" value="#000000" />
-                                سایز فونت: <input type="number" name="bpb_settings[${target}][${newIndex}][font_size]" value="14" style="width: 60px;" />
+                                رنگ (Color / Farbe): <input type="text" class="bpb-color-picker" name="bpb_settings[${target}][${newIndex}][color]" value="#000000" />
+                                سایز فونت (Font Size / Schriftgröße): <input type="number" name="bpb_settings[${target}][${newIndex}][font_size]" value="14" style="width: 60px;" />
 
-                                <button type="button" class="button bpb-remove-row">حذف</button>
+                                <button type="button" class="button bpb-remove-row">حذف (Remove / Entfernen)</button>
 
                                 <input type="hidden" name="bpb_settings[${target}][${newIndex}][order]" value="${newIndex}" class="bpb-order-field">
                             </td>
@@ -341,7 +341,7 @@ function bpb_render_settings_page() {
         </script>
         <hr>
         <div style="background:#fef3c7; padding:15px; border:1px solid #fcd34d;">
-            <strong>تبلیغ ویژه:</strong> اجرای کمپین گوگل ادز برای کسب‌وکار شما با سایت با ما - <a href="https://siteebama.com" target="_blank">اطلاعات بیشتر</a>
+            <strong>تبلیغ ویژه (Special Offer / Sonderangebot):</strong> اجرای کمپین گوگل ادز برای کسب‌وکار شما با سایت با ما - <a href="https://siteebama.com" target="_blank">اطلاعات بیشتر (More info / Weitere Informationen)</a>
         </div>
     </div>
     <?php

--- a/readme.txt
+++ b/readme.txt
@@ -9,10 +9,18 @@ License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 دکمه تماس برای شعب مختلف مخصوص موبایل با قابلیت تنظیم رنگ و نمایش تبلیغ در پنل
+Mobile phone buttons for different branches with color customization and admin panel ads
+Mobile Anruf-Buttons für verschiedene Filialen mit Farbanpassung und Admin-Panel-Werbung
 
 == Description ==
 
 این پلاگین به شما این امکان را می دهد که برای هر یک از شعب کسب و کار خود، یک دکمه تماس جداگانه در نسخه موبایل سایت خود نمایش دهید. شما می توانید رنگ، متن و شماره تماس هر دکمه را به صورت جداگانه تنظیم کنید.
+
+**English:**
+This plugin allows you to display a separate call button for each of your business branches on the mobile version of your website. You can customize the color, text, and phone number of each button individually.
+
+**Deutsch:**
+Dieses Plugin ermöglicht es Ihnen, für jede Ihrer Geschäftsfilialen in der mobilen Version Ihrer Website einen separaten Anruf-Button anzuzeigen. Sie können Farbe, Text und Telefonnummer für jeden Button individuell anpassen.
 
 == Installation ==
 
@@ -20,17 +28,45 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 2. پلاگین را فعال کنید.
 3. به منوی "تماس شعب" در پنل مدیریت وردپرس خود بروید و تنظیمات را انجام دهید.
 
+**English:**
+1. Install the plugin via the Plugins page in WordPress.
+2. Activate the plugin.
+3. Go to the "Branch Phone Buttons" menu in your WordPress admin panel and configure the settings.
+
+**Deutsch:**
+1. Installieren Sie das Plugin über die Plugins-Seite in WordPress.
+2. Aktivieren Sie das Plugin.
+3. Gehen Sie zum Menü "Branch Phone Buttons" in Ihrem WordPress-Admin-Panel und nehmen Sie die Einstellungen vor.
+
 == Frequently Asked Questions ==
 
 * آیا این پلاگین با همه قالب ها سازگار است؟
 بله، این پلاگین با اکثر قالب های استاندارد وردپرس سازگار است.
 
+**English:**
+* Is this plugin compatible with all themes?
+Yes, this plugin is compatible with most standard WordPress themes.
+
+**Deutsch:**
+* Ist dieses Plugin mit allen Themes kompatibel?
+Ja, dieses Plugin ist mit den meisten Standard-WordPress-Themes kompatibel.
+
 == Screenshots ==
 
-1.  نمایی از دکمه های تماس در موبایل
-2.  نمایی از صفحه تنظیمات پلاگین
+1. نمایی از دکمه های تماس در موبایل
+2. نمایی از صفحه تنظیمات پلاگین
+
+**English:**
+1. View of call buttons on mobile
+2. View of the plugin settings page
+
+**Deutsch:**
+1. Ansicht der Anruf-Buttons auf dem Handy
+2. Ansicht der Plugin-Einstellungsseite
 
 == Changelog ==
 
 = 1.0 =
 * انتشار اولیه پلاگین.
+* Initial release of the plugin.
+* Erste Veröffentlichung des Plugins.


### PR DESCRIPTION
This PR adds English and German translations to the plugin's `readme.txt`, `README.md`, and the admin settings page (`admin/settings-page.php`) as requested. The UI strings in the settings page have been updated to display Persian, English, and German side-by-side for a localized view. The JavaScript template for dynamically adding rows has also been updated to match the translated PHP output.

---
*PR created automatically by Jules for task [3264484249533186916](https://jules.google.com/task/3264484249533186916) started by @IranDec*