### PR TITLE
Add extensive customisation options for device, shape, page and animations

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -55,6 +55,47 @@ function bpb_render_settings_page() {
                     </td>
                 </tr>
                 <tr>
+                    <th scope="row"><?php echo esc_html(bpb_t('نمایش در دستگاه‌ها', 'Display Devices', 'Anzeigegeräte')); ?></th>
+                    <td>
+                        <select name="bpb_settings[display_device]">
+                            <option value="mobile_only" <?php selected($settings['display_device'] ?? 'mobile_only', 'mobile_only'); ?>><?php echo esc_html(bpb_t('فقط در موبایل', 'Mobile Only', 'Nur Handy')); ?></option>
+                            <option value="desktop_only" <?php selected($settings['display_device'] ?? 'mobile_only', 'desktop_only'); ?>><?php echo esc_html(bpb_t('فقط در دسکتاپ', 'Desktop Only', 'Nur Desktop')); ?></option>
+                            <option value="all" <?php selected($settings['display_device'] ?? 'mobile_only', 'all'); ?>><?php echo esc_html(bpb_t('همه دستگاه‌ها', 'All Devices', 'Alle Geräte')); ?></option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php echo esc_html(bpb_t('شکل دکمه‌ها', 'Button Shape', 'Tastenform')); ?></th>
+                    <td>
+                        <select name="bpb_settings[button_shape]">
+                            <option value="oval" <?php selected($settings['button_shape'] ?? 'oval', 'oval'); ?>><?php echo esc_html(bpb_t('بیضی', 'Oval', 'Oval')); ?></option>
+                            <option value="circle" <?php selected($settings['button_shape'] ?? 'oval', 'circle'); ?>><?php echo esc_html(bpb_t('دایره', 'Circle', 'Kreis')); ?></option>
+                            <option value="rectangle" <?php selected($settings['button_shape'] ?? 'oval', 'rectangle'); ?>><?php echo esc_html(bpb_t('مستطیل', 'Rectangle', 'Rechteck')); ?></option>
+                            <option value="rounded" <?php selected($settings['button_shape'] ?? 'oval', 'rounded'); ?>><?php echo esc_html(bpb_t('مستطیل گوشه گرد', 'Rounded Rectangle', 'Abgerundetes Rechteck')); ?></option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php echo esc_html(bpb_t('صفحات نمایش', 'Display Pages', 'Anzeigeseiten')); ?></th>
+                    <td>
+                        <?php
+                        $pages = get_pages();
+                        $selected_pages = $settings['display_pages'] ?? [];
+                        if (empty($pages)) {
+                            echo '<p>' . esc_html(bpb_t('صفحه‌ای یافت نشد.', 'No pages found.', 'Keine Seiten gefunden.')) . '</p>';
+                        } else {
+                            echo '<div style="max-height: 150px; overflow-y: auto; border: 1px solid #ccc; padding: 10px;">';
+                            foreach ($pages as $page) {
+                                $checked = in_array($page->ID, $selected_pages) ? 'checked' : '';
+                                echo '<label style="display:block;"><input type="checkbox" name="bpb_settings[display_pages][]" value="' . esc_attr($page->ID) . '" ' . $checked . '> ' . esc_html($page->post_title) . '</label>';
+                            }
+                            echo '</div>';
+                            echo '<p class="description">' . esc_html(bpb_t('اگر هیچکدام انتخاب نشوند، در تمام صفحات نمایش داده می‌شود (مگر اینکه تیک صفحه اصلی زده شده باشد).', 'If none selected, it will show on all pages (unless Show only on homepage is checked).', 'Wenn nichts ausgewählt ist, wird es auf allen Seiten angezeigt (es sei denn, Nur auf Startseite anzeigen ist aktiviert).')) . '</p>';
+                        }
+                        ?>
+                    </td>
+                </tr>
+                <tr>
                     <th scope="row"><?php echo esc_html(bpb_t('تأخیر نمایش (ثانیه)', 'Display Delay (sec)', 'Anzeigeverzögerung (Sek.)')); ?></th>
                     <td>
                         <input type="number" name="bpb_settings[delay]" value="<?php echo esc_attr($settings['delay'] ?? 0); ?>" min="0" />
@@ -149,6 +190,14 @@ function bpb_render_settings_page() {
                                         <option value="off_hours" <?php selected($timing, 'off_hours'); ?>><?php echo esc_html(bpb_t('فقط خارج از ساعات کاری', 'Off Hours Only', 'Nur außerhalb der Geschäftszeiten')); ?></option>
                                     </select>
 
+                                    <?php echo esc_html(bpb_t('انیمیشن', 'Animation', 'Animation')); ?>:
+                                    <?php $anim = $branch['animation'] ?? 'none'; ?>
+                                    <select name="bpb_settings[branches][<?php echo $i ?>][animation]">
+                                        <option value="none" <?php selected($anim, 'none'); ?>><?php echo esc_html(bpb_t('بدون انیمیشن', 'None', 'Keine')); ?></option>
+                                        <option value="shake" <?php selected($anim, 'shake'); ?>><?php echo esc_html(bpb_t('لرزش', 'Shake', 'Schütteln')); ?></option>
+                                        <option value="glow" <?php selected($anim, 'glow'); ?>><?php echo esc_html(bpb_t('درخشش', 'Glow', 'Glühen')); ?></option>
+                                    </select>
+
                                     <?php echo esc_html(bpb_t('رنگ', 'Color', 'Farbe')); ?>: <input type="text" class="bpb-color-picker" name="bpb_settings[branches][<?php echo $i ?>][color]" value="<?php echo esc_attr($branch['color']) ?>" />
                                     <?php echo esc_html(bpb_t('سایز فونت', 'Font Size', 'Schriftgröße')); ?>: <input type="number" name="bpb_settings[branches][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($branch['font_size'] ?? 14) ?>" style="width: 60px;" />
 
@@ -205,6 +254,14 @@ function bpb_render_settings_page() {
                                         <option value="always" <?php selected($timing, 'always'); ?>><?php echo esc_html(bpb_t('همیشه', 'Always', 'Immer')); ?></option>
                                         <option value="biz_hours" <?php selected($timing, 'biz_hours'); ?>><?php echo esc_html(bpb_t('فقط در ساعات کاری', 'Business Hours Only', 'Nur Geschäftszeiten')); ?></option>
                                         <option value="off_hours" <?php selected($timing, 'off_hours'); ?>><?php echo esc_html(bpb_t('فقط خارج از ساعات کاری', 'Off Hours Only', 'Nur außerhalb der Geschäftszeiten')); ?></option>
+                                    </select>
+
+                                    <?php echo esc_html(bpb_t('انیمیشن', 'Animation', 'Animation')); ?>:
+                                    <?php $anim = $contact['animation'] ?? 'none'; ?>
+                                    <select name="bpb_settings[contacts][<?php echo $i ?>][animation]">
+                                        <option value="none" <?php selected($anim, 'none'); ?>><?php echo esc_html(bpb_t('بدون انیمیشن', 'None', 'Keine')); ?></option>
+                                        <option value="shake" <?php selected($anim, 'shake'); ?>><?php echo esc_html(bpb_t('لرزش', 'Shake', 'Schütteln')); ?></option>
+                                        <option value="glow" <?php selected($anim, 'glow'); ?>><?php echo esc_html(bpb_t('درخشش', 'Glow', 'Glühen')); ?></option>
                                     </select>
 
                                     <?php echo esc_html(bpb_t('رنگ', 'Color', 'Farbe')); ?>: <input type="text" class="bpb-color-picker" name="bpb_settings[contacts][<?php echo $i ?>][color]" value="<?php echo esc_attr($contact['color']) ?>" />
@@ -269,6 +326,10 @@ function bpb_render_settings_page() {
                 icon: '<?php echo esc_js(bpb_t("آیکون", "Icon", "Symbol")); ?>',
                 link: '<?php echo esc_js(bpb_t("لینک", "Link", "Link")); ?>',
                 display_time: '<?php echo esc_js(bpb_t("زمان نمایش", "Display Time", "Anzeigezeit")); ?>',
+                animation: '<?php echo esc_js(bpb_t("انیمیشن", "Animation", "Animation")); ?>',
+                anim_none: '<?php echo esc_js(bpb_t("بدون انیمیشن", "None", "Keine")); ?>',
+                anim_shake: '<?php echo esc_js(bpb_t("لرزش (تکان خوردن)", "Shake", "Schütteln")); ?>',
+                anim_glow: '<?php echo esc_js(bpb_t("درخشش (نور دور دکمه)", "Glow", "Glühen")); ?>',
                 always: '<?php echo esc_js(bpb_t("همیشه", "Always", "Immer")); ?>',
                 biz_hours: '<?php echo esc_js(bpb_t("فقط در ساعات کاری", "Business Hours Only", "Nur Geschäftszeiten")); ?>',
                 off_hours: '<?php echo esc_js(bpb_t("فقط خارج از ساعات کاری", "Off Hours Only", "Nur außerhalb der Geschäftszeiten")); ?>',
@@ -354,6 +415,13 @@ function bpb_render_settings_page() {
                                     <option value="always">${bpb_i18n.always}</option>
                                     <option value="biz_hours">${bpb_i18n.biz_hours}</option>
                                     <option value="off_hours">${bpb_i18n.off_hours}</option>
+                                </select>
+
+                                ${bpb_i18n.animation}:
+                                <select name="bpb_settings[${target}][${newIndex}][animation]">
+                                    <option value="none">${bpb_i18n.anim_none}</option>
+                                    <option value="shake">${bpb_i18n.anim_shake}</option>
+                                    <option value="glow">${bpb_i18n.anim_glow}</option>
                                 </select>
 
                                 ${bpb_i18n.color}: <input type="text" class="bpb-color-picker" name="bpb_settings[${target}][${newIndex}][color]" value="#000000" />

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -81,7 +81,69 @@
 }
 
 @media (min-width: 768px) {
-    .bpb-container {
-        display: none;
+    .bpb-hide-desktop {
+        display: none !important;
     }
+}
+@media (max-width: 767px) {
+    .bpb-hide-mobile {
+        display: none !important;
+    }
+}
+
+/* Shape Classes */
+.bpb-shape-oval .bpb-button {
+    border-radius: 50px;
+}
+.bpb-shape-circle .bpb-button {
+    border-radius: 50%;
+    aspect-ratio: 1 / 1;
+}
+.bpb-shape-rectangle .bpb-button {
+    border-radius: 0;
+}
+.bpb-shape-rounded .bpb-button {
+    border-radius: 10px;
+}
+
+/* Flat style overrides for shapes */
+.bpb-style-flat.bpb-shape-circle .bpb-button,
+.bpb-style-flat.bpb-shape-oval .bpb-button,
+.bpb-style-flat.bpb-shape-rounded .bpb-button {
+    margin: 5px;
+}
+
+/* Icon only */
+.bpb-icon-only {
+    padding: 15px !important;
+    flex-direction: row !important;
+}
+.bpb-icon-only .bpb-button-label {
+    display: none !important;
+}
+.bpb-icon-only .bpb-button-icon {
+    margin: 0 !important;
+}
+
+/* Animations */
+@keyframes bpb-shake {
+    0% { transform: translateX(0); }
+    25% { transform: translateX(-5px) rotate(-5deg); }
+    50% { transform: translateX(5px) rotate(5deg); }
+    75% { transform: translateX(-5px) rotate(-5deg); }
+    100% { transform: translateX(0); }
+}
+
+@keyframes bpb-glow {
+    0% { box-shadow: 0 0 5px currentColor; }
+    50% { box-shadow: 0 0 20px currentColor, 0 0 30px currentColor; }
+    100% { box-shadow: 0 0 5px currentColor; }
+}
+
+.bpb-anim-shake {
+    animation: bpb-shake 2s infinite;
+}
+
+.bpb-anim-glow {
+    animation: bpb-glow 2s infinite;
 }

--- a/branch-phone-branches.php
+++ b/branch-phone-branches.php
@@ -57,7 +57,7 @@ function bpb_admin_enqueue_assets($hook) {
 add_action('admin_enqueue_scripts', 'bpb_admin_enqueue_assets');
 
 function bpb_display_buttons() {
-    if (!wp_is_mobile()) return;
+    // We handle device checking later based on settings
 
     // Check Page Builders (Divi Visual Builder, Elementor Preview, Customizer)
     if (isset($_GET['et_fb']) && $_GET['et_fb'] === '1') return; // Divi
@@ -66,8 +66,16 @@ function bpb_display_buttons() {
 
     $options = get_option('bpb_settings', bpb_default_settings());
 
+    // Check Device Rules
+    $device = $options['display_device'] ?? 'mobile_only';
+    if ($device === 'mobile_only' && !wp_is_mobile()) return;
+    if ($device === 'desktop_only' && wp_is_mobile()) return;
+
     // Check Display Rules
     if (!empty($options['show_only_homepage']) && !is_front_page()) return;
+    if (!empty($options['display_pages']) && is_array($options['display_pages'])) {
+        if (!is_page($options['display_pages'])) return;
+    }
     if (!empty($options['hide_on_woo_checkout']) && function_exists('is_woocommerce')) {
         if (is_cart() || is_checkout()) return;
     }
@@ -88,7 +96,14 @@ function bpb_display_buttons() {
 
     $delay = isset($options['delay']) ? intval($options['delay']) * 1000 : 0;
     $display_style = isset($options['display_style']) ? $options['display_style'] : 'flat';
-    $container_class = 'bpb-container bpb-style-' . esc_attr($display_style);
+    $button_shape = isset($options['button_shape']) ? $options['button_shape'] : 'oval';
+
+    $container_class = 'bpb-container bpb-style-' . esc_attr($display_style) . ' bpb-shape-' . esc_attr($button_shape);
+    if ($device === 'mobile_only') {
+        $container_class .= ' bpb-hide-desktop';
+    } elseif ($device === 'desktop_only') {
+        $container_class .= ' bpb-hide-mobile';
+    }
 
     // Business Hours Logic
     $current_time = current_time('H:i');
@@ -117,6 +132,13 @@ function bpb_display_buttons() {
 
         $type = $branch['type'] ?? 'tel';
         $icon = $branch['icon'] ?? 'phone';
+        $animation = $branch['animation'] ?? 'none';
+        $label = $branch['label'] ?? '';
+
+        $button_class = 'bpb-button';
+        if ($animation === 'shake') $button_class .= ' bpb-anim-shake';
+        if ($animation === 'glow') $button_class .= ' bpb-anim-glow';
+        if (empty($label)) $button_class .= ' bpb-icon-only';
 
         $href = '#';
         if ($type === 'tel') $href = 'tel:' . esc_attr($val);
@@ -126,7 +148,7 @@ function bpb_display_buttons() {
         elseif ($type === 'link') $href = esc_url($val);
 
         $icon_svg = bpb_get_icon_svg($icon);
-        $safe_label = esc_js($branch['label'] ?? $type);
+        $safe_label = esc_js($label ?: $type);
 
         $onclick_parts = [];
         // GA Tracking
@@ -140,10 +162,12 @@ function bpb_display_buttons() {
 
         $onclick = ' onclick="' . implode(' ', $onclick_parts) . '"';
 
-        echo '<a href="' . $href . '" style="' . $style . '" class="bpb-button"' . $onclick . '>'
-           . '<span class="bpb-button-icon">' . $icon_svg . '</span>'
-           . '<span class="bpb-button-label">' . esc_html($branch['label'] ?? '') . '</span>'
-           . '</a>';
+        echo '<a href="' . $href . '" style="' . $style . '" class="' . esc_attr($button_class) . '"' . $onclick . '>'
+           . '<span class="bpb-button-icon">' . $icon_svg . '</span>';
+        if (!empty($label)) {
+            echo '<span class="bpb-button-label">' . esc_html($label) . '</span>';
+        }
+        echo '</a>';
     }
     echo '</div>';
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -12,15 +12,18 @@ function bpb_default_settings() {
         'enable_ga_tracking' => 1,
         'biz_time_start' => '08:00',
         'biz_time_end' => '17:00',
+        'display_device' => 'mobile_only',
+        'display_pages' => [],
+        'button_shape' => 'oval',
         'branches' => [
-            ['label' => 'شعبه شمال تهران', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#e63946', 'timing' => 'always'],
-            ['label' => 'شعبه غرب تهران',  'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#f1a208', 'timing' => 'always'],
-            ['label' => 'شعبه مرکز تهران', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#52b788', 'timing' => 'always'],
-            ['label' => 'شعبه شرق تهران',  'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#118ab2', 'timing' => 'always'],
+            ['label' => 'شعبه شمال تهران', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#e63946', 'timing' => 'always', 'animation' => 'none'],
+            ['label' => 'شعبه غرب تهران',  'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#f1a208', 'timing' => 'always', 'animation' => 'none'],
+            ['label' => 'شعبه مرکز تهران', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#52b788', 'timing' => 'always', 'animation' => 'none'],
+            ['label' => 'شعبه شرق تهران',  'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#118ab2', 'timing' => 'always', 'animation' => 'none'],
         ],
         'contacts' => [
-            ['label' => 'تماس', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#e63946', 'timing' => 'biz_hours'],
-            ['label' => 'پیامگیر',  'value' => '', 'type' => 'telegram', 'icon' => 'telegram', 'color' => '#118ab2', 'timing' => 'off_hours'],
+            ['label' => 'تماس', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#e63946', 'timing' => 'biz_hours', 'animation' => 'none'],
+            ['label' => 'پیامگیر',  'value' => '', 'type' => 'telegram', 'icon' => 'telegram', 'color' => '#118ab2', 'timing' => 'off_hours', 'animation' => 'none'],
         ]
     ];
 }


### PR DESCRIPTION
The user requested several new features:
1. Ability to display the plugin on specific devices (mobile only, desktop only, or all devices).
2. Animations for individual buttons (like shake or glow effects to catch the eye).
3. The ability to select specific pages where the buttons should appear.
4. Support for icon-only buttons (when the label is empty, the button should shrink to its shape and not display an empty text box).
5. The ability to select the button shape (circle, oval, rectangle, rounded rectangle).

This PR implements these features by:
- Modifying `includes/functions.php` to add default values for device visibility, button shape, display pages, and animation per button.
- Updating `admin/settings-page.php` to include UI controls for the new global settings and per-button settings, modifying both the PHP render loop and the JS row template.
- Adjusting `assets/css/style.css` to introduce classes for shapes (`.bpb-shape-*`), icon-only rendering (`.bpb-icon-only`), dynamic device visibility (`.bpb-hide-mobile`, `.bpb-hide-desktop`), and keyframe animations (`.bpb-anim-shake`, `.bpb-anim-glow`).
- Updating `branch-phone-branches.php` to conditionally render based on the user's selected pages and device rules, appending the appropriate CSS classes to the container and buttons.

---
*PR created automatically by Jules for task [14301612596340448395](https://jules.google.com/task/14301612596340448395) started by @IranDec*