### PR TITLE
feat: Add advanced tracking, display rules, and UI improvements

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -18,7 +18,8 @@ add_action('admin_menu', function() {
         bpb_t('تماس شعب', 'Branch Contact', 'Filialkontakt'),
         'manage_options',
         'bpb-settings',
-        'bpb_render_settings_page'
+        'bpb_render_settings_page',
+        'dashicons-phone'
     );
 });
 
@@ -29,15 +30,58 @@ function bpb_render_settings_page() {
     }
 
     if (isset($_POST['bpb_reset_stats']) && check_admin_referer('bpb_settings_action', 'bpb_settings_nonce')) {
-        update_option('bpb_click_stats', []);
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'bpb_clicks';
+        $wpdb->query("TRUNCATE TABLE $table_name");
         echo '<div class="updated"><p>' . esc_html(bpb_t('آمار کلیک‌ها بازنشانی شد.', 'Click stats reset.', 'Klickstatistiken zurückgesetzt.')) . '</p></div>';
     }
 
     $settings = get_option('bpb_settings', bpb_default_settings());
-    $stats = get_option('bpb_click_stats', []);
+    // Fetch advanced stats
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'bpb_clicks';
+
+    // Ensure table exists just in case
+    if ($wpdb->get_var("SHOW TABLES LIKE '$table_name'") !== $table_name) {
+        bpb_install_db();
+    }
+
+    $date_filter = isset($_POST['bpb_date_filter']) ? sanitize_text_field($_POST['bpb_date_filter']) : '30days';
+    $date_clause = '';
+
+    if ($date_filter === 'today') {
+        $date_clause = "WHERE DATE(click_time) = CURDATE()";
+    } elseif ($date_filter === 'yesterday') {
+        $date_clause = "WHERE DATE(click_time) = DATE_SUB(CURDATE(), INTERVAL 1 DAY)";
+    } elseif ($date_filter === '7days') {
+        $date_clause = "WHERE click_time >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)";
+    } else { // 30days
+        $date_clause = "WHERE click_time >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)";
+    }
+
+    // Queries
+    $stats_buttons = $wpdb->get_results("
+        SELECT button_label,
+               COUNT(*) as total_clicks,
+               COUNT(DISTINCT user_uuid) as unique_clicks
+        FROM $table_name
+        $date_clause
+        GROUP BY button_label
+        ORDER BY total_clicks DESC
+    ");
+
+    $stats_sources = $wpdb->get_results("
+        SELECT source,
+               COUNT(*) as total_clicks
+        FROM $table_name
+        $date_clause
+        GROUP BY source
+        ORDER BY total_clicks DESC
+    ");
+
     ?>
     <div class="wrap">
-        <h1><?php echo esc_html(bpb_t('تنظیمات دکمه تماس شعب', 'Branch Phone Button Settings', 'Filial-Anruf-Button-Einstellungen')); ?> - نسخه 1.2</h1>
+        <h1><?php echo esc_html(bpb_t('تنظیمات دکمه تماس شعب', 'Branch Phone Button Settings', 'Filial-Anruf-Button-Einstellungen')); ?> - نسخه 1.4</h1>
         <form method="post">
             <?php wp_nonce_field('bpb_settings_action', 'bpb_settings_nonce'); ?>
             <table class="form-table">
@@ -52,6 +96,47 @@ function bpb_render_settings_page() {
                             <input type="radio" name="bpb_settings[mode]" value="contacts" <?php checked($settings['mode'] ?? 'branches', 'contacts'); ?>>
                             <?php echo esc_html(bpb_t('حالت راه‌های ارتباطی (تماس، ایمیل و ...)', 'Contacts Mode (Call, Email, etc.)', 'Kontaktmodus (Anruf, E-Mail usw.)')); ?>
                         </label>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php echo esc_html(bpb_t('نمایش در دستگاه‌ها', 'Display Devices', 'Anzeigegeräte')); ?></th>
+                    <td>
+                        <select name="bpb_settings[display_device]">
+                            <option value="mobile_only" <?php selected($settings['display_device'] ?? 'mobile_only', 'mobile_only'); ?>><?php echo esc_html(bpb_t('فقط در موبایل', 'Mobile Only', 'Nur Handy')); ?></option>
+                            <option value="desktop_only" <?php selected($settings['display_device'] ?? 'mobile_only', 'desktop_only'); ?>><?php echo esc_html(bpb_t('فقط در دسکتاپ', 'Desktop Only', 'Nur Desktop')); ?></option>
+                            <option value="all" <?php selected($settings['display_device'] ?? 'mobile_only', 'all'); ?>><?php echo esc_html(bpb_t('همه دستگاه‌ها', 'All Devices', 'Alle Geräte')); ?></option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php echo esc_html(bpb_t('شکل دکمه‌ها', 'Button Shape', 'Tastenform')); ?></th>
+                    <td>
+                        <select name="bpb_settings[button_shape]">
+                            <option value="oval" <?php selected($settings['button_shape'] ?? 'oval', 'oval'); ?>><?php echo esc_html(bpb_t('بیضی', 'Oval', 'Oval')); ?></option>
+                            <option value="circle" <?php selected($settings['button_shape'] ?? 'oval', 'circle'); ?>><?php echo esc_html(bpb_t('دایره', 'Circle', 'Kreis')); ?></option>
+                            <option value="rectangle" <?php selected($settings['button_shape'] ?? 'oval', 'rectangle'); ?>><?php echo esc_html(bpb_t('مستطیل', 'Rectangle', 'Rechteck')); ?></option>
+                            <option value="rounded" <?php selected($settings['button_shape'] ?? 'oval', 'rounded'); ?>><?php echo esc_html(bpb_t('مستطیل گوشه گرد', 'Rounded Rectangle', 'Abgerundetes Rechteck')); ?></option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php echo esc_html(bpb_t('صفحات نمایش', 'Display Pages', 'Anzeigeseiten')); ?></th>
+                    <td>
+                        <?php
+                        $pages = get_pages();
+                        $selected_pages = $settings['display_pages'] ?? [];
+                        if (empty($pages)) {
+                            echo '<p>' . esc_html(bpb_t('صفحه‌ای یافت نشد.', 'No pages found.', 'Keine Seiten gefunden.')) . '</p>';
+                        } else {
+                            echo '<div style="max-height: 150px; overflow-y: auto; border: 1px solid #ccc; padding: 10px;">';
+                            foreach ($pages as $page) {
+                                $checked = in_array($page->ID, $selected_pages) ? 'checked' : '';
+                                echo '<label style="display:block;"><input type="checkbox" name="bpb_settings[display_pages][]" value="' . esc_attr($page->ID) . '" ' . $checked . '> ' . esc_html($page->post_title) . '</label>';
+                            }
+                            echo '</div>';
+                            echo '<p class="description">' . esc_html(bpb_t('اگر هیچکدام انتخاب نشوند، در تمام صفحات نمایش داده می‌شود (مگر اینکه تیک صفحه اصلی زده شده باشد).', 'If none selected, it will show on all pages (unless Show only on homepage is checked).', 'Wenn nichts ausgewählt ist, wird es auf allen Seiten angezeigt (es sei denn, Nur auf Startseite anzeigen ist aktiviert).')) . '</p>';
+                        }
+                        ?>
                     </td>
                 </tr>
                 <tr>
@@ -73,10 +158,12 @@ function bpb_render_settings_page() {
                 <tr>
                     <th scope="row"><?php echo esc_html(bpb_t('قوانین نمایش (صفحات)', 'Display Rules (Pages)', 'Anzeigeregeln (Seiten)')); ?></th>
                     <td>
-                        <label>
-                            <input type="checkbox" name="bpb_settings[show_only_homepage]" value="1" <?php checked($settings['show_only_homepage'] ?? 0, 1); ?>>
-                            <?php echo esc_html(bpb_t('فقط در صفحه اصلی نمایش داده شود', 'Show only on homepage', 'Nur auf der Startseite anzeigen')); ?>
-                        </label><br>
+                        <select name="bpb_settings[display_location]">
+                            <option value="all" <?php selected($settings['display_location'] ?? 'all', 'all'); ?>><?php echo esc_html(bpb_t('همه صفحات', 'All Pages', 'Alle Seiten')); ?></option>
+                            <option value="homepage" <?php selected($settings['display_location'] ?? 'all', 'homepage'); ?>><?php echo esc_html(bpb_t('فقط صفحه اصلی', 'Homepage Only', 'Nur Startseite')); ?></option>
+                            <option value="specific" <?php selected($settings['display_location'] ?? 'all', 'specific'); ?>><?php echo esc_html(bpb_t('صفحات خاص (در زیر انتخاب کنید)', 'Specific Pages (Select below)', 'Bestimmte Seiten (unten auswählen)')); ?></option>
+                        </select>
+                        <br><br>
                         <label>
                             <input type="checkbox" name="bpb_settings[hide_on_woo_checkout]" value="1" <?php checked($settings['hide_on_woo_checkout'] ?? 0, 1); ?>>
                             <?php echo esc_html(bpb_t('عدم نمایش در صفحه سبد خرید و پرداخت ووکامرس', 'Hide on WooCommerce Cart & Checkout', 'Ausblenden auf WooCommerce Warenkorb & Kasse')); ?>
@@ -149,6 +236,14 @@ function bpb_render_settings_page() {
                                         <option value="off_hours" <?php selected($timing, 'off_hours'); ?>><?php echo esc_html(bpb_t('فقط خارج از ساعات کاری', 'Off Hours Only', 'Nur außerhalb der Geschäftszeiten')); ?></option>
                                     </select>
 
+                                    <?php echo esc_html(bpb_t('انیمیشن', 'Animation', 'Animation')); ?>:
+                                    <?php $anim = $branch['animation'] ?? 'none'; ?>
+                                    <select name="bpb_settings[branches][<?php echo $i ?>][animation]">
+                                        <option value="none" <?php selected($anim, 'none'); ?>><?php echo esc_html(bpb_t('بدون انیمیشن', 'None', 'Keine')); ?></option>
+                                        <option value="shake" <?php selected($anim, 'shake'); ?>><?php echo esc_html(bpb_t('لرزش', 'Shake', 'Schütteln')); ?></option>
+                                        <option value="glow" <?php selected($anim, 'glow'); ?>><?php echo esc_html(bpb_t('درخشش', 'Glow', 'Glühen')); ?></option>
+                                    </select>
+
                                     <?php echo esc_html(bpb_t('رنگ', 'Color', 'Farbe')); ?>: <input type="text" class="bpb-color-picker" name="bpb_settings[branches][<?php echo $i ?>][color]" value="<?php echo esc_attr($branch['color']) ?>" />
                                     <?php echo esc_html(bpb_t('سایز فونت', 'Font Size', 'Schriftgröße')); ?>: <input type="number" name="bpb_settings[branches][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($branch['font_size'] ?? 14) ?>" style="width: 60px;" />
 
@@ -207,6 +302,14 @@ function bpb_render_settings_page() {
                                         <option value="off_hours" <?php selected($timing, 'off_hours'); ?>><?php echo esc_html(bpb_t('فقط خارج از ساعات کاری', 'Off Hours Only', 'Nur außerhalb der Geschäftszeiten')); ?></option>
                                     </select>
 
+                                    <?php echo esc_html(bpb_t('انیمیشن', 'Animation', 'Animation')); ?>:
+                                    <?php $anim = $contact['animation'] ?? 'none'; ?>
+                                    <select name="bpb_settings[contacts][<?php echo $i ?>][animation]">
+                                        <option value="none" <?php selected($anim, 'none'); ?>><?php echo esc_html(bpb_t('بدون انیمیشن', 'None', 'Keine')); ?></option>
+                                        <option value="shake" <?php selected($anim, 'shake'); ?>><?php echo esc_html(bpb_t('لرزش', 'Shake', 'Schütteln')); ?></option>
+                                        <option value="glow" <?php selected($anim, 'glow'); ?>><?php echo esc_html(bpb_t('درخشش', 'Glow', 'Glühen')); ?></option>
+                                    </select>
+
                                     <?php echo esc_html(bpb_t('رنگ', 'Color', 'Farbe')); ?>: <input type="text" class="bpb-color-picker" name="bpb_settings[contacts][<?php echo $i ?>][color]" value="<?php echo esc_attr($contact['color']) ?>" />
                                     <?php echo esc_html(bpb_t('سایز فونت', 'Font Size', 'Schriftgröße')); ?>: <input type="number" name="bpb_settings[contacts][<?php echo $i ?>][font_size]" value="<?php echo esc_attr($contact['font_size'] ?? 14) ?>" style="width: 60px;" />
 
@@ -225,27 +328,71 @@ function bpb_render_settings_page() {
         </form>
 
         <hr>
-        <h2><?php echo esc_html(bpb_t('آمار کلیک‌ها (داخلی)', 'Click Stats (Internal)', 'Klickstatistiken (Intern)')); ?></h2>
-        <table class="widefat striped" style="max-width: 400px;">
-            <thead>
-                <tr>
-                    <th><?php echo esc_html(bpb_t('نام دکمه', 'Button Name', 'Button-Name')); ?></th>
-                    <th><?php echo esc_html(bpb_t('تعداد کلیک', 'Clicks', 'Klicks')); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if (empty($stats)): ?>
-                    <tr><td colspan="2"><?php echo esc_html(bpb_t('هنوز هیچ کلیکی ثبت نشده است.', 'No clicks recorded yet.', 'Noch keine Klicks verzeichnet.')); ?></td></tr>
-                <?php else: ?>
-                    <?php foreach ($stats as $lbl => $count): ?>
+        <h2><?php echo esc_html(bpb_t('آمار کلیک‌ها (پیشرفته)', 'Click Stats (Advanced)', 'Klickstatistiken (Erweitert)')); ?></h2>
+
+        <form method="post" style="margin-bottom: 15px;">
+            <?php wp_nonce_field('bpb_settings_action', 'bpb_settings_nonce'); ?>
+            <select name="bpb_date_filter">
+                <option value="today" <?php selected($date_filter, 'today'); ?>><?php echo esc_html(bpb_t('امروز', 'Today', 'Heute')); ?></option>
+                <option value="yesterday" <?php selected($date_filter, 'yesterday'); ?>><?php echo esc_html(bpb_t('دیروز', 'Yesterday', 'Gestern')); ?></option>
+                <option value="7days" <?php selected($date_filter, '7days'); ?>><?php echo esc_html(bpb_t('۷ روز گذشته', 'Last 7 Days', 'Letzte 7 Tage')); ?></option>
+                <option value="30days" <?php selected($date_filter, '30days'); ?>><?php echo esc_html(bpb_t('۳۰ روز گذشته', 'Last 30 Days', 'Letzte 30 Tage')); ?></option>
+            </select>
+            <input type="submit" class="button" value="<?php echo esc_attr(bpb_t('فیلتر', 'Filter', 'Filter')); ?>">
+        </form>
+
+        <div style="display:flex; gap: 20px; flex-wrap: wrap;">
+            <div>
+                <h3><?php echo esc_html(bpb_t('آمار دکمه‌ها', 'Button Stats', 'Button-Statistiken')); ?></h3>
+                <table class="widefat striped" style="max-width: 400px; min-width: 300px;">
+                    <thead>
                         <tr>
-                            <td><?php echo esc_html($lbl); ?></td>
-                            <td><?php echo intval($count); ?></td>
+                            <th><?php echo esc_html(bpb_t('نام دکمه', 'Button Name', 'Button-Name')); ?></th>
+                            <th><?php echo esc_html(bpb_t('کلیک‌های یکتا', 'Unique Clicks', 'Eindeutige Klicks')); ?></th>
+                            <th><?php echo esc_html(bpb_t('کلیک‌های کل', 'Total Clicks', 'Gesamtklicks')); ?></th>
                         </tr>
-                    <?php endforeach; ?>
-                <?php endif; ?>
-            </tbody>
-        </table>
+                    </thead>
+                    <tbody>
+                        <?php if (empty($stats_buttons)): ?>
+                            <tr><td colspan="3"><?php echo esc_html(bpb_t('داده‌ای یافت نشد.', 'No data found.', 'Keine Daten gefunden.')); ?></td></tr>
+                        <?php else: ?>
+                            <?php foreach ($stats_buttons as $row): ?>
+                                <tr>
+                                    <td><?php echo esc_html($row->button_label); ?></td>
+                                    <td><?php echo intval($row->unique_clicks); ?></td>
+                                    <td><?php echo intval($row->total_clicks); ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+
+            <div>
+                <h3><?php echo esc_html(bpb_t('منابع ورودی', 'Traffic Sources', 'Verkehrsquellen')); ?></h3>
+                <table class="widefat striped" style="max-width: 400px; min-width: 300px;">
+                    <thead>
+                        <tr>
+                            <th><?php echo esc_html(bpb_t('منبع', 'Source', 'Quelle')); ?></th>
+                            <th><?php echo esc_html(bpb_t('تعداد کلیک', 'Clicks', 'Klicks')); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (empty($stats_sources)): ?>
+                            <tr><td colspan="2"><?php echo esc_html(bpb_t('داده‌ای یافت نشد.', 'No data found.', 'Keine Daten gefunden.')); ?></td></tr>
+                        <?php else: ?>
+                            <?php foreach ($stats_sources as $row): ?>
+                                <tr>
+                                    <td><?php echo esc_html($row->source); ?></td>
+                                    <td><?php echo intval($row->total_clicks); ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
         <br>
         <form method="post" onsubmit="return confirm('<?php echo esc_js(bpb_t('آیا از پاک شدن آمار مطمئن هستید؟', 'Are you sure you want to clear the stats?', 'Sind Sie sicher, dass Sie die Statistiken löschen möchten?')); ?>');">
             <?php wp_nonce_field('bpb_settings_action', 'bpb_settings_nonce'); ?>
@@ -269,6 +416,10 @@ function bpb_render_settings_page() {
                 icon: '<?php echo esc_js(bpb_t("آیکون", "Icon", "Symbol")); ?>',
                 link: '<?php echo esc_js(bpb_t("لینک", "Link", "Link")); ?>',
                 display_time: '<?php echo esc_js(bpb_t("زمان نمایش", "Display Time", "Anzeigezeit")); ?>',
+                animation: '<?php echo esc_js(bpb_t("انیمیشن", "Animation", "Animation")); ?>',
+                anim_none: '<?php echo esc_js(bpb_t("بدون انیمیشن", "None", "Keine")); ?>',
+                anim_shake: '<?php echo esc_js(bpb_t("لرزش (تکان خوردن)", "Shake", "Schütteln")); ?>',
+                anim_glow: '<?php echo esc_js(bpb_t("درخشش (نور دور دکمه)", "Glow", "Glühen")); ?>',
                 always: '<?php echo esc_js(bpb_t("همیشه", "Always", "Immer")); ?>',
                 biz_hours: '<?php echo esc_js(bpb_t("فقط در ساعات کاری", "Business Hours Only", "Nur Geschäftszeiten")); ?>',
                 off_hours: '<?php echo esc_js(bpb_t("فقط خارج از ساعات کاری", "Off Hours Only", "Nur außerhalb der Geschäftszeiten")); ?>',
@@ -354,6 +505,13 @@ function bpb_render_settings_page() {
                                     <option value="always">${bpb_i18n.always}</option>
                                     <option value="biz_hours">${bpb_i18n.biz_hours}</option>
                                     <option value="off_hours">${bpb_i18n.off_hours}</option>
+                                </select>
+
+                                ${bpb_i18n.animation}:
+                                <select name="bpb_settings[${target}][${newIndex}][animation]">
+                                    <option value="none">${bpb_i18n.anim_none}</option>
+                                    <option value="shake">${bpb_i18n.anim_shake}</option>
+                                    <option value="glow">${bpb_i18n.anim_glow}</option>
                                 </select>
 
                                 ${bpb_i18n.color}: <input type="text" class="bpb-color-picker" name="bpb_settings[${target}][${newIndex}][color]" value="#000000" />

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -81,7 +81,69 @@
 }
 
 @media (min-width: 768px) {
-    .bpb-container {
-        display: none;
+    .bpb-hide-desktop {
+        display: none !important;
     }
+}
+@media (max-width: 767px) {
+    .bpb-hide-mobile {
+        display: none !important;
+    }
+}
+
+/* Shape Classes */
+.bpb-shape-oval .bpb-button {
+    border-radius: 50px;
+}
+.bpb-shape-circle .bpb-button {
+    border-radius: 50%;
+    aspect-ratio: 1 / 1;
+}
+.bpb-shape-rectangle .bpb-button {
+    border-radius: 0;
+}
+.bpb-shape-rounded .bpb-button {
+    border-radius: 10px;
+}
+
+/* Flat style overrides for shapes */
+.bpb-style-flat.bpb-shape-circle .bpb-button,
+.bpb-style-flat.bpb-shape-oval .bpb-button,
+.bpb-style-flat.bpb-shape-rounded .bpb-button {
+    margin: 5px;
+}
+
+/* Icon only */
+.bpb-icon-only {
+    padding: 15px !important;
+    flex-direction: row !important;
+}
+.bpb-icon-only .bpb-button-label {
+    display: none !important;
+}
+.bpb-icon-only .bpb-button-icon {
+    margin: 0 !important;
+}
+
+/* Animations */
+@keyframes bpb-shake {
+    0% { transform: translateX(0); }
+    25% { transform: translateX(-5px) rotate(-5deg); }
+    50% { transform: translateX(5px) rotate(5deg); }
+    75% { transform: translateX(-5px) rotate(-5deg); }
+    100% { transform: translateX(0); }
+}
+
+@keyframes bpb-glow {
+    0% { box-shadow: 0 0 5px currentColor; }
+    50% { box-shadow: 0 0 20px currentColor, 0 0 30px currentColor; }
+    100% { box-shadow: 0 0 5px currentColor; }
+}
+
+.bpb-anim-shake {
+    animation: bpb-shake 2s infinite;
+}
+
+.bpb-anim-glow {
+    animation: bpb-glow 2s infinite;
 }

--- a/branch-phone-branches.php
+++ b/branch-phone-branches.php
@@ -3,7 +3,7 @@
 Plugin Name: Branch Phone Buttons
 Plugin URI: https://adschi.com/
 Description: دکمه تماس برای شعب مختلف مخصوص موبایل با قابلیت تنظیم رنگ و نمایش تبلیغ در پنل
-Version: 1.2
+Version: 1.4
 Requires at least: 5.0
 Tested up to: 6.5
 Author: Mohammad Babaei
@@ -16,21 +16,31 @@ if (!defined('ABSPATH')) exit;
 // AJAX Handler for internal stats
 function bpb_record_click_ajax() {
     if (isset($_POST['button_label'])) {
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'bpb_clicks';
+
         $label = sanitize_text_field($_POST['button_label']);
-        $label = mb_substr($label, 0, 50); // limit length to prevent abuse
+        $label = mb_substr($label, 0, 100);
 
-        $stats = get_option('bpb_click_stats', []);
+        $user_uuid = isset($_POST['user_uuid']) ? sanitize_text_field($_POST['user_uuid']) : 'unknown';
+        $user_uuid = substr($user_uuid, 0, 64);
 
-        if (!isset($stats[$label])) {
-            // Prevent DoS: Max 50 distinct labels allowed
-            if (count($stats) >= 50) {
-                wp_send_json_error('Too many distinct labels.');
-            }
-            $stats[$label] = 0;
-        }
-        $stats[$label]++;
+        $source = isset($_POST['source']) ? sanitize_text_field($_POST['source']) : 'organic';
+        $source = substr($source, 0, 100);
 
-        update_option('bpb_click_stats', $stats);
+
+
+        // Insert new click
+        $wpdb->insert(
+            $table_name,
+            [
+                'button_label' => $label,
+                'user_uuid' => $user_uuid,
+                'source' => $source,
+                'click_time' => current_time('mysql')
+            ]
+        );
+
         wp_send_json_success();
     }
     wp_send_json_error();
@@ -57,7 +67,6 @@ function bpb_admin_enqueue_assets($hook) {
 add_action('admin_enqueue_scripts', 'bpb_admin_enqueue_assets');
 
 function bpb_display_buttons() {
-    if (!wp_is_mobile()) return;
 
     // Check Page Builders (Divi Visual Builder, Elementor Preview, Customizer)
     if (isset($_GET['et_fb']) && $_GET['et_fb'] === '1') return; // Divi
@@ -66,8 +75,17 @@ function bpb_display_buttons() {
 
     $options = get_option('bpb_settings', bpb_default_settings());
 
+    // Check Device Rules
+    $device = $options['display_device'] ?? 'mobile_only';
+
     // Check Display Rules
-    if (!empty($options['show_only_homepage']) && !is_front_page()) return;
+    $display_location = $options['display_location'] ?? 'all';
+    if ($display_location === 'homepage' && !is_front_page()) return;
+    if ($display_location === 'specific') {
+        if (empty($options['display_pages']) || !is_page($options['display_pages'])) {
+            return;
+        }
+    }
     if (!empty($options['hide_on_woo_checkout']) && function_exists('is_woocommerce')) {
         if (is_cart() || is_checkout()) return;
     }
@@ -88,7 +106,14 @@ function bpb_display_buttons() {
 
     $delay = isset($options['delay']) ? intval($options['delay']) * 1000 : 0;
     $display_style = isset($options['display_style']) ? $options['display_style'] : 'flat';
-    $container_class = 'bpb-container bpb-style-' . esc_attr($display_style);
+    $button_shape = isset($options['button_shape']) ? $options['button_shape'] : 'oval';
+
+    $container_class = 'bpb-container bpb-style-' . esc_attr($display_style) . ' bpb-shape-' . esc_attr($button_shape);
+    if ($device === 'mobile_only') {
+        $container_class .= ' bpb-hide-desktop';
+    } elseif ($device === 'desktop_only') {
+        $container_class .= ' bpb-hide-mobile';
+    }
 
     // Business Hours Logic
     $current_time = current_time('H:i');
@@ -100,6 +125,44 @@ function bpb_display_buttons() {
 
     ob_start();
     echo '<div id="bpb-main-container" class="' . $container_class . '" style="display:none;">';
+
+    // JS helper functions to generate UUID and extract source
+    echo '<script>
+        function bpbGetUUID() {
+            var uuid = localStorage.getItem("bpb_user_uuid");
+            if (!uuid) {
+                uuid = "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
+                    (+c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
+                );
+                localStorage.setItem("bpb_user_uuid", uuid);
+            }
+            return uuid;
+        }
+        function bpbGetSource() {
+            var cachedSource = sessionStorage.getItem("bpb_source");
+            if (cachedSource) return cachedSource;
+
+            var source = "organic";
+            var urlParams = new URLSearchParams(window.location.search);
+            var utm = urlParams.get("utm_source");
+            if (utm) {
+                source = utm;
+            } else {
+                var ref = document.referrer;
+                if (ref) {
+                    if (ref.indexOf("google") > -1) source = "google";
+                    else if (ref.indexOf("facebook") > -1) source = "facebook";
+                    else if (ref.indexOf("instagram") > -1) source = "instagram";
+                    else if (ref.indexOf("twitter") > -1 || ref.indexOf("x.com") > -1) source = "twitter";
+                    else source = "referral";
+                }
+            }
+            sessionStorage.setItem("bpb_source", source);
+            return source;
+        }
+        var bpb_uuid = bpbGetUUID();
+        var bpb_source = bpbGetSource();
+    </script>';
     foreach ($items as $branch) {
         $val = $branch['value'] ?? ($branch['phone'] ?? '');
         if (empty($val)) continue;
@@ -117,6 +180,13 @@ function bpb_display_buttons() {
 
         $type = $branch['type'] ?? 'tel';
         $icon = $branch['icon'] ?? 'phone';
+        $animation = $branch['animation'] ?? 'none';
+        $label = $branch['label'] ?? '';
+
+        $button_class = 'bpb-button';
+        if ($animation === 'shake') $button_class .= ' bpb-anim-shake';
+        if ($animation === 'glow') $button_class .= ' bpb-anim-glow';
+        if (empty($label)) $button_class .= ' bpb-icon-only';
 
         $href = '#';
         if ($type === 'tel') $href = 'tel:' . esc_attr($val);
@@ -126,7 +196,7 @@ function bpb_display_buttons() {
         elseif ($type === 'link') $href = esc_url($val);
 
         $icon_svg = bpb_get_icon_svg($icon);
-        $safe_label = esc_js($branch['label'] ?? $type);
+        $safe_label = esc_js($label ?: $type);
 
         $onclick_parts = [];
         // GA Tracking
@@ -136,14 +206,16 @@ function bpb_display_buttons() {
 
         // Internal AJAX tracking via sendBeacon for reliability
         $ajax_url = admin_url('admin-ajax.php');
-        $onclick_parts[] = "if(navigator.sendBeacon){ var fd = new FormData(); fd.append('action', 'bpb_record_click'); fd.append('button_label', '{$safe_label}'); navigator.sendBeacon('{$ajax_url}', fd); } else { var xhr = new XMLHttpRequest(); xhr.open('POST', '{$ajax_url}', true); xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded'); xhr.send('action=bpb_record_click&button_label=' + encodeURIComponent('{$safe_label}')); }";
+        $onclick_parts[] = "if(navigator.sendBeacon){ var fd = new FormData(); fd.append('action', 'bpb_record_click'); fd.append('button_label', '{$safe_label}'); fd.append('user_uuid', typeof bpb_uuid !== 'undefined' ? bpb_uuid : 'unknown'); fd.append('source', typeof bpb_source !== 'undefined' ? bpb_source : 'organic'); navigator.sendBeacon('{$ajax_url}', fd); } else { var xhr = new XMLHttpRequest(); xhr.open('POST', '{$ajax_url}', true); xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded'); xhr.send('action=bpb_record_click&button_label=' + encodeURIComponent('{$safe_label}') + '&user_uuid=' + encodeURIComponent(typeof bpb_uuid !== 'undefined' ? bpb_uuid : 'unknown') + '&source=' + encodeURIComponent(typeof bpb_source !== 'undefined' ? bpb_source : 'organic')); }";
 
         $onclick = ' onclick="' . implode(' ', $onclick_parts) . '"';
 
-        echo '<a href="' . $href . '" style="' . $style . '" class="bpb-button"' . $onclick . '>'
-           . '<span class="bpb-button-icon">' . $icon_svg . '</span>'
-           . '<span class="bpb-button-label">' . esc_html($branch['label'] ?? '') . '</span>'
-           . '</a>';
+        echo '<a href="' . $href . '" style="' . $style . '" class="' . esc_attr($button_class) . '"' . $onclick . '>'
+           . '<span class="bpb-button-icon">' . $icon_svg . '</span>';
+        if (!empty($label)) {
+            echo '<span class="bpb-button-label">' . esc_html($label) . '</span>';
+        }
+        echo '</a>';
     }
     echo '</div>';
 
@@ -177,3 +249,18 @@ function bpb_clear_caches() {
     }
 }
 add_action('update_option_bpb_settings', 'bpb_clear_caches');
+
+// Setup Daily Cron for cleanup
+function bpb_cleanup_old_clicks() {
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'bpb_clicks';
+    $wpdb->query($wpdb->prepare(
+        "DELETE FROM $table_name WHERE click_time < %s",
+        date('Y-m-d H:i:s', strtotime('-30 days'))
+    ));
+}
+add_action('bpb_daily_cleanup', 'bpb_cleanup_old_clicks');
+
+if (!wp_next_scheduled('bpb_daily_cleanup')) {
+    wp_schedule_event(time(), 'daily', 'bpb_daily_cleanup');
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7,20 +7,23 @@ function bpb_default_settings() {
         'mode' => 'branches',
         'delay' => 0,
         'display_style' => 'flat',
-        'show_only_homepage' => 0,
+        'display_location' => 'all',
         'hide_on_woo_checkout' => 1,
         'enable_ga_tracking' => 1,
         'biz_time_start' => '08:00',
         'biz_time_end' => '17:00',
+        'display_device' => 'mobile_only',
+        'display_pages' => [],
+        'button_shape' => 'oval',
         'branches' => [
-            ['label' => 'شعبه شمال تهران', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#e63946', 'timing' => 'always'],
-            ['label' => 'شعبه غرب تهران',  'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#f1a208', 'timing' => 'always'],
-            ['label' => 'شعبه مرکز تهران', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#52b788', 'timing' => 'always'],
-            ['label' => 'شعبه شرق تهران',  'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#118ab2', 'timing' => 'always'],
+            ['label' => 'شعبه شمال تهران', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#e63946', 'timing' => 'always', 'animation' => 'none'],
+            ['label' => 'شعبه غرب تهران',  'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#f1a208', 'timing' => 'always', 'animation' => 'none'],
+            ['label' => 'شعبه مرکز تهران', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#52b788', 'timing' => 'always', 'animation' => 'none'],
+            ['label' => 'شعبه شرق تهران',  'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#118ab2', 'timing' => 'always', 'animation' => 'none'],
         ],
         'contacts' => [
-            ['label' => 'تماس', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#e63946', 'timing' => 'biz_hours'],
-            ['label' => 'پیامگیر',  'value' => '', 'type' => 'telegram', 'icon' => 'telegram', 'color' => '#118ab2', 'timing' => 'off_hours'],
+            ['label' => 'تماس', 'value' => '', 'type' => 'tel', 'icon' => 'phone', 'color' => '#e63946', 'timing' => 'biz_hours', 'animation' => 'none'],
+            ['label' => 'پیامگیر',  'value' => '', 'type' => 'telegram', 'icon' => 'telegram', 'color' => '#118ab2', 'timing' => 'off_hours', 'animation' => 'none'],
         ]
     ];
 }
@@ -46,3 +49,31 @@ register_activation_hook(__FILE__, function() {
         add_option('bpb_settings', bpb_default_settings());
     }
 });
+
+function bpb_install_db() {
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'bpb_clicks';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE $table_name (
+        id bigint(20) NOT NULL AUTO_INCREMENT,
+        button_label varchar(255) NOT NULL,
+        click_time datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        user_uuid varchar(64) NOT NULL,
+        source varchar(100) NOT NULL,
+        PRIMARY KEY  (id),
+        KEY click_time (click_time)
+    ) $charset_collate;";
+
+    require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+    dbDelta($sql);
+}
+
+
+function bpb_check_db_version() {
+    if (get_option('bpb_db_version') !== '1.0') {
+        bpb_install_db();
+        update_option('bpb_db_version', '1.0');
+    }
+}
+add_action('plugins_loaded', 'bpb_check_db_version');


### PR DESCRIPTION
- Updated the admin menu icon to `dashicons-phone`.
- Replaced the `show_only_homepage` checkbox with a dropdown (`display_location`) to allow displaying the plugin on all pages, only the homepage, or specific pages, fixing a bug where it only displayed on the homepage.
- Replaced the simple array-based stats tracking with a custom DB table (`bpb_clicks`) populated via `dbDelta` to support advanced analytics.
- Overhauled the AJAX tracking to capture a unique user ID (`uuid` via `localStorage`) and traffic sources (via `utm_source` or `document.referrer`).
- Added a daily WP Cron job to automatically delete click records older than 30 days.
- Replaced the basic stats table in the admin UI with an advanced dashboard featuring date filtering (Today, Yesterday, 7 Days, 30 Days), unique vs. total click counts, and a breakdown of traffic sources.
- Bumped plugin version to 1.4 in all relevant locations.