### PR TITLE
Fix popup on Mac Safari and update version to 1.7

### DIFF
--- a/branch-phone-branches.php
+++ b/branch-phone-branches.php
@@ -3,7 +3,7 @@
 Plugin Name: Branch Phone Buttons
 Plugin URI: https://adschi.com/
 Description: دکمه تماس برای شعب مختلف مخصوص موبایل با قابلیت تنظیم رنگ و نمایش تبلیغ در پنل
-Version: 1.6
+Version: 1.7
 Requires at least: 5.0
 Tested up to: 6.5
 Author: Mohammad Babaei
@@ -231,14 +231,14 @@ function bpb_display_buttons_html($is_shortcode = false) {
             $phone_behavior = $options['phone_behavior'] ?? 'direct';
             if ($phone_behavior === 'all_popup' || $phone_behavior === 'desktop_popup') {
                 $is_desktop_class = ($phone_behavior === 'desktop_popup') ? ' bpb-desktop-only-popup' : '';
-                $onclick_parts[] = "bpb_open_phone_modal('".esc_js($val)."', this.classList.contains('bpb-desktop-only-popup')); return !this.classList.contains('bpb-desktop-only-popup') && window.innerWidth > 768 ? false : (this.classList.contains('bpb-desktop-only-popup') && window.innerWidth <= 768 ? true : false);";
+                $onclick_parts[] = "bpb_open_phone_modal('".esc_js($val)."', this.classList.contains('bpb-desktop-only-popup')); if (!this.classList.contains('bpb-desktop-only-popup') && window.innerWidth > 768) { event.preventDefault(); return false; } else if (this.classList.contains('bpb-desktop-only-popup') && window.innerWidth <= 768) { return true; } else { event.preventDefault(); return false; }";
                 $button_class .= $is_desktop_class;
             }
         } elseif ($type === 'mailto') {
             $email_behavior = $options['email_behavior'] ?? 'direct';
             if ($email_behavior === 'all_popup' || $email_behavior === 'desktop_popup') {
                 $is_desktop_class = ($email_behavior === 'desktop_popup') ? ' bpb-desktop-only-popup' : '';
-                $onclick_parts[] = "bpb_open_email_modal('".esc_js($val)."', this.classList.contains('bpb-desktop-only-popup')); return !this.classList.contains('bpb-desktop-only-popup') && window.innerWidth > 768 ? false : (this.classList.contains('bpb-desktop-only-popup') && window.innerWidth <= 768 ? true : false);";
+                $onclick_parts[] = "bpb_open_email_modal('".esc_js($val)."', this.classList.contains('bpb-desktop-only-popup')); if (!this.classList.contains('bpb-desktop-only-popup') && window.innerWidth > 768) { event.preventDefault(); return false; } else if (this.classList.contains('bpb-desktop-only-popup') && window.innerWidth <= 768) { return true; } else { event.preventDefault(); return false; }";
                 $button_class .= $is_desktop_class;
             }
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://adschi.com/
 Tags: phone, call, button, branch
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 1.6
+Stable tag: 1.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -69,6 +69,10 @@ Ja, dieses Plugin ist mit den meisten Standard-WordPress-Themes kompatibel.
 2. نمایی از صفحه تنظیمات پلاگین
 
 == Changelog ==
+
+= 1.7 =
+* Fixed an issue with desktop popups not displaying properly on Mac Safari for `tel:` and `mailto:` links.
+* رفع مشکل عدم نمایش صحیح پاپ‌آپ‌های دسکتاپ برای لینک‌های `tel:` و `mailto:` در مرورگر سافاری روی مک.
 
 = 1.6 =
 * Added desktop popups and click behaviors for phone and email links (with copy feature and quick access to mail apps).


### PR DESCRIPTION
Updated the `onclick` handler logic for `tel:` and `mailto:` links to explicitly use `event.preventDefault()` to fix an issue where Mac Safari would ignore `return false` and directly open the link. Also incremented plugin version to 1.7 in `branch-phone-branches.php` and `readme.txt`.

---
*PR created automatically by Jules for task [7400239634659927255](https://jules.google.com/task/7400239634659927255) started by @IranDec*